### PR TITLE
feat: Add HTTP REST API layer for future frontend integrations

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,238 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/nilesh32236/vector-mcp-go/internal/config"
+	"github.com/nilesh32236/vector-mcp-go/internal/db"
+	"github.com/nilesh32236/vector-mcp-go/internal/indexer"
+)
+
+type StoreGetter func(ctx context.Context) (*db.Store, error)
+
+type Server struct {
+	cfg         *config.Config
+	storeGetter StoreGetter
+	embedder    indexer.Embedder
+	srv         *http.Server
+}
+
+func NewServer(cfg *config.Config, storeGetter StoreGetter, embedder indexer.Embedder) *Server {
+	mux := http.NewServeMux()
+
+	server := &Server{
+		cfg:         cfg,
+		storeGetter: storeGetter,
+		embedder:    embedder,
+	}
+
+	mux.HandleFunc("GET /api/health", server.handleHealth)
+	mux.HandleFunc("POST /api/search", server.handleSearch)
+	mux.HandleFunc("POST /api/context", server.handleContext)
+	mux.HandleFunc("POST /api/todo", server.handleTodo)
+
+	addr := fmt.Sprintf(":%s", cfg.ApiPort)
+	server.srv = &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	return server
+}
+
+func (s *Server) Start() error {
+	if s.cfg.Logger != nil {
+		s.cfg.Logger.Info("Starting HTTP API server", "port", s.cfg.ApiPort)
+	}
+	err := s.srv.ListenAndServe()
+	if err != nil && err != http.ErrServerClosed {
+		return err
+	}
+	return nil
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	if s.cfg.Logger != nil {
+		s.cfg.Logger.Info("Shutting down HTTP API server")
+	}
+	return s.srv.Shutdown(ctx)
+}
+
+func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "ok",
+		"version": "1.0",
+	})
+}
+
+type SearchRequest struct {
+	Query string `json:"query"`
+	TopK  int    `json:"top_k"`
+}
+
+type SearchResponse struct {
+	ID         string            `json:"id"`
+	Text       string            `json:"text"`
+	Similarity float32           `json:"similarity"`
+	Metadata   map[string]string `json:"metadata"`
+}
+
+func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
+	var req SearchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.TopK <= 0 {
+		req.TopK = 5 // default
+	}
+
+	emb, err := s.embedder.Embed(r.Context(), req.Query)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	store, err := s.storeGetter(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// For the global brain search, we don't filter by project ID unless requested,
+	// but store.Search currently takes projectIDs. Passing an empty slice searches everything.
+	records, err := store.Search(r.Context(), emb, req.TopK, []string{})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var resp []SearchResponse
+	for _, rec := range records {
+		resp = append(resp, SearchResponse{
+			ID:         rec.ID,
+			Text:       rec.Content,
+			Similarity: rec.Similarity,
+			Metadata:   rec.Metadata,
+		})
+	}
+
+	if resp == nil {
+		resp = []SearchResponse{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(resp)
+}
+
+type ContextRequest struct {
+	Text     string            `json:"text"`
+	Source   string            `json:"source"`
+	Metadata map[string]string `json:"metadata"`
+}
+
+func (s *Server) handleContext(w http.ResponseWriter, r *http.Request) {
+	var req ContextRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	emb, err := s.embedder.Embed(r.Context(), req.Text)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	store, err := s.storeGetter(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	meta := make(map[string]string)
+	for k, v := range req.Metadata {
+		meta[k] = v
+	}
+	meta["type"] = "manual_context"
+	meta["source"] = req.Source
+
+	id := fmt.Sprintf("manual_%d", time.Now().UnixNano())
+
+	err = store.Insert(r.Context(), []db.Record{{
+		ID:        id,
+		Content:   req.Text,
+		Embedding: emb,
+		Metadata:  meta,
+	}})
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "success",
+		"message": "Context added to Global Brain",
+	})
+}
+
+type TodoRequest struct {
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Priority    string `json:"priority"`
+}
+
+func (s *Server) handleTodo(w http.ResponseWriter, r *http.Request) {
+	var req TodoRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	combinedText := req.Title + "\n" + req.Description
+	emb, err := s.embedder.Embed(r.Context(), combinedText)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	store, err := s.storeGetter(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	meta := map[string]string{
+		"type":     "todo",
+		"status":   "open",
+		"priority": req.Priority,
+	}
+
+	id := fmt.Sprintf("todo_%d", time.Now().UnixNano())
+
+	err = store.Insert(r.Context(), []db.Record{{
+		ID:        id,
+		Content:   combinedText,
+		Embedding: emb,
+		Metadata:  meta,
+	}})
+
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":  "success",
+		"message": "TODO stored in vector database",
+	})
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,207 @@
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/nilesh32236/vector-mcp-go/internal/config"
+	"github.com/nilesh32236/vector-mcp-go/internal/db"
+)
+
+type mockEmbedder struct {
+	dimension int
+}
+
+func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	emb := make([]float32, m.dimension)
+	for i := range emb {
+		emb[i] = 0.1
+	}
+	return emb, nil
+}
+
+// Better yet, let's just create a real temp db store for the test
+func setupTestServer(t *testing.T) (*Server, func()) {
+	cfg := &config.Config{
+		ApiPort:   "8080",
+		Dimension: 1024,
+	}
+
+	tempDir := t.TempDir()
+	store, err := db.Connect(context.Background(), tempDir, "test_collection")
+	if err != nil {
+		t.Fatalf("failed to connect to db: %v", err)
+	}
+
+	sg := func(ctx context.Context) (*db.Store, error) {
+		return store, nil
+	}
+
+	emb := &mockEmbedder{dimension: 1024}
+
+	srv := NewServer(cfg, sg, emb)
+
+	cleanup := func() {
+		// nothing special to cleanup
+	}
+
+	return srv, cleanup
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	srv, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	req, err := http.NewRequest("GET", "/api/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v",
+			status, http.StatusOK)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp["status"] != "ok" {
+		t.Errorf("expected status 'ok', got '%v'", resp["status"])
+	}
+}
+
+func TestContextEndpoint(t *testing.T) {
+	srv, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	body := ContextRequest{
+		Text:   "This is some manual context",
+		Source: "manual_input",
+		Metadata: map[string]string{
+			"custom_key": "custom_value",
+		},
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req, err := http.NewRequest("POST", "/api/context", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp["status"] != "success" {
+		t.Errorf("expected status 'success', got '%v'", resp["status"])
+	}
+
+	// Verify it was actually inserted
+	store, _ := srv.storeGetter(context.Background())
+	if store.Count() != 1 {
+		t.Errorf("expected 1 record in store, got %d", store.Count())
+	}
+}
+
+func TestTodoEndpoint(t *testing.T) {
+	srv, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	body := TodoRequest{
+		Title:       "Fix a bug",
+		Description: "The bug is very buggy",
+		Priority:    "high",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	req, err := http.NewRequest("POST", "/api/todo", bytes.NewReader(bodyBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var resp map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp["status"] != "success" {
+		t.Errorf("expected status 'success', got '%v'", resp["status"])
+	}
+
+	store, _ := srv.storeGetter(context.Background())
+	if store.Count() != 1 {
+		t.Errorf("expected 1 record in store, got %d", store.Count())
+	}
+}
+
+func TestSearchEndpoint(t *testing.T) {
+	srv, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	// 1. Insert something via context endpoint
+	ctxReqBody := ContextRequest{
+		Text:   "This is search target",
+		Source: "test",
+		Metadata: map[string]string{
+			"key": "value",
+		},
+	}
+	ctxBytes, _ := json.Marshal(ctxReqBody)
+	req1, _ := http.NewRequest("POST", "/api/context", bytes.NewReader(ctxBytes))
+	rr1 := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr1, req1)
+
+	// 2. Search for it
+	searchBody := SearchRequest{
+		Query: "search target",
+		TopK:  5,
+	}
+	searchBytes, _ := json.Marshal(searchBody)
+	req2, _ := http.NewRequest("POST", "/api/search", bytes.NewReader(searchBytes))
+	rr2 := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr2, req2)
+
+	if status := rr2.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var resp []SearchResponse
+	if err := json.NewDecoder(rr2.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(resp) != 1 {
+		t.Errorf("expected 1 search result, got %d", len(resp))
+	} else {
+		if resp[0].Text != "This is search target" {
+			t.Errorf("expected text 'This is search target', got '%v'", resp[0].Text)
+		}
+		if resp[0].Metadata["type"] != "manual_context" {
+			t.Errorf("expected metadata type 'manual_context', got '%v'", resp[0].Metadata["type"])
+		}
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	HFToken        string
 	Dimension      int
 	DisableWatcher bool
+	ApiPort        string
 	Logger         *slog.Logger
 }
 
@@ -87,6 +88,11 @@ func LoadConfig(dataDirOverride, modelsDirOverride, dbPathOverride string) *Conf
 
 	disableWatcher := os.Getenv("DISABLE_FILE_WATCHER") == "true"
 
+	apiPort := os.Getenv("API_PORT")
+	if apiPort == "" {
+		apiPort = "8080"
+	}
+
 	return &Config{
 		ProjectRoot:    projectRoot,
 		DataDir:        dataDir,
@@ -97,6 +103,7 @@ func LoadConfig(dataDirOverride, modelsDirOverride, dbPathOverride string) *Conf
 		HFToken:        os.Getenv("HF_TOKEN"),
 		Dimension:      1024,
 		DisableWatcher: disableWatcher,
+		ApiPort:        apiPort,
 		Logger:         logger,
 	}
 }

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/nilesh32236/vector-mcp-go/internal/api"
 	"github.com/nilesh32236/vector-mcp-go/internal/config"
 	"github.com/nilesh32236/vector-mcp-go/internal/daemon"
 	"github.com/nilesh32236/vector-mcp-go/internal/db"
@@ -119,20 +120,6 @@ func main() {
 		masterServer.UpdateEmbedder(realEmbedder)
 	}
 
-	// Graceful shutdown
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		sig := <-sigChan
-		logger.Info("Received signal, shutting down", "signal", sig)
-		cancel()
-		if isMaster && masterServer != nil {
-			masterServer.Close()
-		}
-		time.Sleep(500 * time.Millisecond)
-		os.Exit(0)
-	}()
-
 	// Initialize dependencies
 	storeGetter := func(ctx context.Context) (*db.Store, error) {
 		return getStore(ctx, cfg, false)
@@ -140,6 +127,36 @@ func main() {
 	freshStoreGetter := func(ctx context.Context) (*db.Store, error) {
 		return getStore(ctx, cfg, true)
 	}
+
+	// Start API server
+	apiSrv := api.NewServer(cfg, storeGetter, embedder)
+	go func() {
+		if err := apiSrv.Start(); err != nil {
+			logger.Error("API server error", "error", err)
+		}
+	}()
+
+	// Graceful shutdown
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigChan
+		logger.Info("Received signal, shutting down", "signal", sig)
+
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer shutdownCancel()
+
+		if err := apiSrv.Shutdown(shutdownCtx); err != nil {
+			logger.Error("API server shutdown error", "error", err)
+		}
+
+		cancel()
+		if isMaster && masterServer != nil {
+			masterServer.Close()
+		}
+		time.Sleep(500 * time.Millisecond)
+		os.Exit(0)
+	}()
 
 	// Initialize worker (only Master processes the queue)
 	if isMaster {


### PR DESCRIPTION
This PR introduces a standalone HTTP REST API layer to `vector-mcp-go` to support a future React frontend. The API server runs on a configurable port (defaulting to 8080) in a separate goroutine so it doesn't block the `stdio` MCP protocol. 

The server exposes 4 JSON endpoints using standard `net/http` and Go 1.22 routing:
* `GET /api/health`: Healthcheck.
* `POST /api/search`: Performs vector search using the global brain (LanceDB).
* `POST /api/context`: Embeds and stores manual context texts into LanceDB.
* `POST /api/todo`: Embeds and stores TODO tasks into LanceDB.

Includes graceful shutdown handling to cleanly close the `http.Server` and a suite of `httptest` unit tests.

---
*PR created automatically by Jules for task [7016128478221535051](https://jules.google.com/task/7016128478221535051) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new HTTP API server with endpoints for health checks, semantic search, context management, and todo creation.
  * Added configurable API port setting for flexible deployment.
  * Implemented graceful shutdown handling for the API server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->