### PR TITLE
feat: Add Phase 2 - Gemini RAG Chat Endpoint

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/nilesh32236/vector-mcp-go/internal/config"
 	"github.com/nilesh32236/vector-mcp-go/internal/db"
 	"github.com/nilesh32236/vector-mcp-go/internal/indexer"
+	"github.com/nilesh32236/vector-mcp-go/internal/llm"
 )
 
 type StoreGetter func(ctx context.Context) (*db.Store, error)
@@ -34,6 +35,7 @@ func NewServer(cfg *config.Config, storeGetter StoreGetter, embedder indexer.Emb
 	mux.HandleFunc("POST /api/search", server.handleSearch)
 	mux.HandleFunc("POST /api/context", server.handleContext)
 	mux.HandleFunc("POST /api/todo", server.handleTodo)
+	mux.HandleFunc("POST /api/chat", server.handleChat)
 
 	addr := fmt.Sprintf(":%s", cfg.ApiPort)
 	server.srv = &http.Server{
@@ -234,5 +236,116 @@ func (s *Server) handleTodo(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]string{
 		"status":  "success",
 		"message": "TODO stored in vector database",
+	})
+}
+
+type ChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type ChatRequest struct {
+	Model    string        `json:"model"`
+	Messages []ChatMessage `json:"messages"`
+}
+
+type ChatResponse struct {
+	ModelUsed string `json:"model_used"`
+	Role      string `json:"role"`
+	Content   string `json:"content"`
+}
+
+func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
+	if s.cfg.GeminiApiKey == "" {
+		http.Error(w, `{"error": "Gemini API key is not configured"}`, http.StatusNotImplemented)
+		return
+	}
+
+	var req ChatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	model := req.Model
+	if model == "" {
+		model = s.cfg.DefaultGeminiModel
+	}
+
+	if len(req.Messages) == 0 {
+		http.Error(w, "messages array cannot be empty", http.StatusBadRequest)
+		return
+	}
+
+	lastMessage := req.Messages[len(req.Messages)-1]
+
+	// 1. Embed the last message
+	emb, err := s.embedder.Embed(r.Context(), lastMessage.Content)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 2. Search for relevant context
+	store, err := s.storeGetter(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	records, err := store.Search(r.Context(), emb, 10, []string{})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 3. Construct context string
+	var contextBuilder string
+	for _, rec := range records {
+		path := ""
+		if p, ok := rec.Metadata["path"]; ok {
+			path = p
+		} else if p, ok := rec.Metadata["file"]; ok {
+			path = p
+		}
+
+		if path != "" {
+			contextBuilder += fmt.Sprintf("File: %s\nCode:\n%s\n\n", path, rec.Content)
+		} else {
+			contextBuilder += fmt.Sprintf("Code:\n%s\n\n", rec.Content)
+		}
+	}
+
+	// 4. Create system prompt
+	systemPrompt := "You are an expert AI coding assistant. Use the provided codebase context to answer the user's question. If the answer is not in the context, say so. \n\nContext:\n" + contextBuilder
+
+	// 5. Map messages to llm.Message
+	var llmMessages []llm.Message
+	for _, msg := range req.Messages {
+		llmMessages = append(llmMessages, llm.Message{
+			Role:    msg.Role,
+			Content: msg.Content,
+		})
+	}
+
+	// 6. Call Gemini
+	// Allow overriding endpoint for testing
+	endpointURL := ""
+	if h := r.Header.Get("X-Test-Gemini-URL"); h != "" {
+		endpointURL = h
+	}
+
+	responseContent, err := llm.GenerateGeminiCompletion(r.Context(), s.cfg.GeminiApiKey, model, systemPrompt, llmMessages, endpointURL)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// 7. Return response
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(ChatResponse{
+		ModelUsed: model,
+		Role:      "assistant",
+		Content:   responseContent,
 	})
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -27,8 +27,10 @@ func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error
 // Better yet, let's just create a real temp db store for the test
 func setupTestServer(t *testing.T) (*Server, func()) {
 	cfg := &config.Config{
-		ApiPort:   "8080",
-		Dimension: 1024,
+		ApiPort:            "8080",
+		Dimension:          1024,
+		GeminiApiKey:       "test-key",
+		DefaultGeminiModel: "gemini-test-model",
 	}
 
 	tempDir := t.TempDir()
@@ -203,5 +205,111 @@ func TestSearchEndpoint(t *testing.T) {
 		if resp[0].Metadata["type"] != "manual_context" {
 			t.Errorf("expected metadata type 'manual_context', got '%v'", resp[0].Metadata["type"])
 		}
+	}
+}
+
+func TestChatEndpoint(t *testing.T) {
+	srv, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	// 1. Insert dummy context
+	ctxReqBody := ContextRequest{
+		Text:   "The indexing worker processes files in the background.",
+		Source: "worker.go",
+		Metadata: map[string]string{
+			"path": "internal/worker/worker.go",
+		},
+	}
+	ctxBytes, _ := json.Marshal(ctxReqBody)
+	req1, _ := http.NewRequest("POST", "/api/context", bytes.NewReader(ctxBytes))
+	rr1 := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr1, req1)
+
+	// 2. Setup mock Gemini server
+	mockGemini := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Verify API Key
+		if r.URL.Query().Get("key") != "test-key" {
+			t.Errorf("expected API key 'test-key', got '%s'", r.URL.Query().Get("key"))
+		}
+
+		// Read and verify request body
+		var geminiReq map[string]interface{}
+		json.NewDecoder(r.Body).Decode(&geminiReq)
+
+		sysInstr, ok := geminiReq["system_instruction"].(map[string]interface{})
+		if !ok {
+			t.Errorf("system_instruction is missing")
+		} else {
+			parts := sysInstr["parts"].([]interface{})
+			text := parts[0].(map[string]interface{})["text"].(string)
+			if !bytes.Contains([]byte(text), []byte("File: internal/worker/worker.go")) {
+				t.Errorf("system instruction does not contain expected file path context")
+			}
+		}
+
+		// Mock response
+		resp := `{
+			"candidates": [
+				{
+					"content": {
+						"parts": [{"text": "It processes files in the background."}]
+					}
+				}
+			]
+		}`
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(resp))
+	}))
+	defer mockGemini.Close()
+
+	// 3. Make chat request
+	chatBody := ChatRequest{
+		Messages: []ChatMessage{
+			{Role: "user", Content: "How does the indexing worker work?"},
+		},
+	}
+	chatBytes, _ := json.Marshal(chatBody)
+	req2, _ := http.NewRequest("POST", "/api/chat", bytes.NewReader(chatBytes))
+	req2.Header.Set("X-Test-Gemini-URL", mockGemini.URL)
+
+	rr2 := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr2, req2)
+
+	if status := rr2.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	var resp ChatResponse
+	if err := json.NewDecoder(rr2.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.ModelUsed != "gemini-test-model" {
+		t.Errorf("expected model 'gemini-test-model', got '%s'", resp.ModelUsed)
+	}
+	if resp.Content != "It processes files in the background." {
+		t.Errorf("expected generated content 'It processes files in the background.', got '%s'", resp.Content)
+	}
+}
+
+func TestChatEndpointNoApiKey(t *testing.T) {
+	srv, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	srv.cfg.GeminiApiKey = "" // Unset API key
+
+	chatBody := ChatRequest{
+		Messages: []ChatMessage{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+	chatBytes, _ := json.Marshal(chatBody)
+	req, _ := http.NewRequest("POST", "/api/chat", bytes.NewReader(chatBytes))
+
+	rr := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr, req)
+
+	if status := rr.Code; status != http.StatusNotImplemented {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotImplemented)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,10 +17,12 @@ type Config struct {
 	LogPath        string
 	ModelName      string
 	HFToken        string
-	Dimension      int
-	DisableWatcher bool
-	ApiPort        string
-	Logger         *slog.Logger
+	Dimension          int
+	DisableWatcher     bool
+	ApiPort            string
+	GeminiApiKey       string
+	DefaultGeminiModel string
+	Logger             *slog.Logger
 }
 
 func LoadConfig(dataDirOverride, modelsDirOverride, dbPathOverride string) *Config {
@@ -93,18 +95,25 @@ func LoadConfig(dataDirOverride, modelsDirOverride, dbPathOverride string) *Conf
 		apiPort = "8080"
 	}
 
+	defaultGeminiModel := os.Getenv("GEMINI_DEFAULT_MODEL")
+	if defaultGeminiModel == "" {
+		defaultGeminiModel = "gemini-2.5-flash"
+	}
+
 	return &Config{
-		ProjectRoot:    projectRoot,
-		DataDir:        dataDir,
-		DbPath:         dbPath,
-		ModelsDir:      modelsDir,
-		LogPath:        logPath,
-		ModelName:      modelName,
-		HFToken:        os.Getenv("HF_TOKEN"),
-		Dimension:      1024,
-		DisableWatcher: disableWatcher,
-		ApiPort:        apiPort,
-		Logger:         logger,
+		ProjectRoot:        projectRoot,
+		DataDir:            dataDir,
+		DbPath:             dbPath,
+		ModelsDir:          modelsDir,
+		LogPath:            logPath,
+		ModelName:          modelName,
+		HFToken:            os.Getenv("HF_TOKEN"),
+		Dimension:          1024,
+		DisableWatcher:     disableWatcher,
+		ApiPort:            apiPort,
+		GeminiApiKey:       os.Getenv("GEMINI_API_KEY"),
+		DefaultGeminiModel: defaultGeminiModel,
+		Logger:             logger,
 	}
 }
 

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -1,0 +1,111 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type Message struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type geminiPart struct {
+	Text string `json:"text"`
+}
+
+type geminiContent struct {
+	Role  string       `json:"role"`
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiSystemInstruction struct {
+	Parts []geminiPart `json:"parts"`
+}
+
+type geminiRequest struct {
+	SystemInstruction *geminiSystemInstruction `json:"system_instruction,omitempty"`
+	Contents          []geminiContent          `json:"contents"`
+}
+
+type geminiResponse struct {
+	Candidates []struct {
+		Content struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"content"`
+	} `json:"candidates"`
+}
+
+// GenerateGeminiCompletion calls the Google Gemini REST API to generate a response.
+func GenerateGeminiCompletion(ctx context.Context, apiKey string, model string, systemPrompt string, messages []Message, endpointURL string) (string, error) {
+	if endpointURL == "" {
+		endpointURL = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", model)
+	}
+
+	reqBody := geminiRequest{}
+
+	if systemPrompt != "" {
+		reqBody.SystemInstruction = &geminiSystemInstruction{
+			Parts: []geminiPart{
+				{Text: systemPrompt},
+			},
+		}
+	}
+
+	for _, msg := range messages {
+		// Gemini uses "user" and "model" roles
+		role := msg.Role
+		if role == "assistant" {
+			role = "model"
+		}
+
+		reqBody.Contents = append(reqBody.Contents, geminiContent{
+			Role: role,
+			Parts: []geminiPart{
+				{Text: msg.Content},
+			},
+		})
+	}
+
+	jsonData, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal gemini request: %w", err)
+	}
+
+	reqURL := fmt.Sprintf("%s?key=%s", endpointURL, apiKey)
+	req, err := http.NewRequestWithContext(ctx, "POST", reqURL, bytes.NewBuffer(jsonData))
+	if err != nil {
+		return "", fmt.Errorf("failed to create http request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to execute http request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("gemini api returned status %d: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	var geminiResp geminiResponse
+	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
+		return "", fmt.Errorf("failed to decode gemini response: %w", err)
+	}
+
+	if len(geminiResp.Candidates) == 0 || len(geminiResp.Candidates[0].Content.Parts) == 0 {
+		return "", fmt.Errorf("gemini api returned no content")
+	}
+
+	return geminiResp.Candidates[0].Content.Parts[0].Text, nil
+}


### PR DESCRIPTION
- Added GEMINI_API_KEY and GEMINI_DEFAULT_MODEL to config.
- Created internal/llm package to handle Google Gemini REST API completion calls, supporting `system_instruction` formatting and mapping user/assistant roles.
- Implemented POST /api/chat endpoint using net/http.
- Implemented vector retrieval for the last user message, looking up the top 10 relevant context chunks in LanceDB.
- Integrated retrieved context into the Gemini system prompt.
- Added graceful fallback to HTTP 501 if the API key is not configured, preventing startup crashes for the background MCP worker.
- Wrote httptest-based unit tests mocking the Gemini API response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chat API endpoint with support for Gemini language models
  * Configure API authentication and select default language model through environment variables

<!-- end of auto-generated comment: release notes by coderabbit.ai -->