### PR TITLE
feat: Add Chat History CRUD and Agentic Memory

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/nilesh32236/vector-mcp-go/internal/chat"
 	"github.com/nilesh32236/vector-mcp-go/internal/config"
 	"github.com/nilesh32236/vector-mcp-go/internal/db"
 	"github.com/nilesh32236/vector-mcp-go/internal/indexer"
@@ -20,18 +21,32 @@ type Server struct {
 	storeGetter StoreGetter
 	embedder    indexer.Embedder
 	srv         *http.Server
+	chatStore   *chat.Store
 }
 
 func NewServer(cfg *config.Config, storeGetter StoreGetter, embedder indexer.Embedder) *Server {
+	chatStore, err := chat.NewStore(cfg.DataDir)
+	if err != nil && cfg.Logger != nil {
+		cfg.Logger.Error("Failed to initialize chat store", "error", err)
+	}
+
 	mux := http.NewServeMux()
 
 	server := &Server{
 		cfg:         cfg,
 		storeGetter: storeGetter,
 		embedder:    embedder,
+		chatStore:   chatStore,
 	}
 
 	mux.HandleFunc("GET /api/health", server.handleHealth)
+
+	// Chat sessions CRUD
+	mux.HandleFunc("GET /api/sessions", server.handleListSessions)
+	mux.HandleFunc("POST /api/sessions", server.handleCreateSession)
+	mux.HandleFunc("GET /api/sessions/{id}", server.handleGetSession)
+	mux.HandleFunc("DELETE /api/sessions/{id}", server.handleDeleteSession)
+
 	mux.HandleFunc("POST /api/search", server.handleSearch)
 	mux.HandleFunc("POST /api/context", server.handleContext)
 	mux.HandleFunc("POST /api/todo", server.handleTodo)
@@ -239,14 +254,110 @@ func (s *Server) handleTodo(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (s *Server) handleListSessions(w http.ResponseWriter, r *http.Request) {
+	if s.chatStore == nil {
+		http.Error(w, "Chat store not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	sessions, err := s.chatStore.ListSessions()
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if sessions == nil {
+		sessions = []chat.Session{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(sessions)
+}
+
+func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
+	if s.chatStore == nil {
+		http.Error(w, "Chat store not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	var req struct {
+		Title string `json:"title"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.Title == "" {
+		req.Title = "New Chat"
+	}
+
+	session, err := s.chatStore.CreateSession(req.Title)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(session)
+}
+
+func (s *Server) handleGetSession(w http.ResponseWriter, r *http.Request) {
+	if s.chatStore == nil {
+		http.Error(w, "Chat store not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "Session ID is required", http.StatusBadRequest)
+		return
+	}
+
+	history, err := s.chatStore.GetSession(id)
+	if err != nil {
+		if err.Error() == "session not found" {
+			http.Error(w, "Session not found", http.StatusNotFound)
+		} else {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(history)
+}
+
+func (s *Server) handleDeleteSession(w http.ResponseWriter, r *http.Request) {
+	if s.chatStore == nil {
+		http.Error(w, "Chat store not initialized", http.StatusInternalServerError)
+		return
+	}
+
+	id := r.PathValue("id")
+	if id == "" {
+		http.Error(w, "Session ID is required", http.StatusBadRequest)
+		return
+	}
+
+	if err := s.chatStore.DeleteSession(id); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "success"})
+}
+
 type ChatMessage struct {
 	Role    string `json:"role"`
 	Content string `json:"content"`
 }
 
 type ChatRequest struct {
-	Model    string        `json:"model"`
-	Messages []ChatMessage `json:"messages"`
+	SessionID string `json:"session_id"`
+	Model     string `json:"model"`
+	Message   string `json:"message"`
 }
 
 type ChatResponse struct {
@@ -261,9 +372,24 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if s.chatStore == nil {
+		http.Error(w, "Chat store not initialized", http.StatusInternalServerError)
+		return
+	}
+
 	var req ChatRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if req.SessionID == "" {
+		http.Error(w, "session_id is required", http.StatusBadRequest)
+		return
+	}
+
+	if req.Message == "" {
+		http.Error(w, "message cannot be empty", http.StatusBadRequest)
 		return
 	}
 
@@ -272,21 +398,28 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		model = s.cfg.DefaultGeminiModel
 	}
 
-	if len(req.Messages) == 0 {
-		http.Error(w, "messages array cannot be empty", http.StatusBadRequest)
+	// 1. Fetch History
+	history, err := s.chatStore.GetSession(req.SessionID)
+	if err != nil {
+		http.Error(w, "Session not found", http.StatusNotFound)
 		return
 	}
 
-	lastMessage := req.Messages[len(req.Messages)-1]
+	// 2. Append User Message
+	userMsg := llm.Message{Role: "user", Content: req.Message}
+	if err := s.chatStore.AppendMessage(req.SessionID, userMsg); err != nil {
+		http.Error(w, "Failed to append user message", http.StatusInternalServerError)
+		return
+	}
+	history.Messages = append(history.Messages, userMsg)
 
-	// 1. Embed the last message
-	emb, err := s.embedder.Embed(r.Context(), lastMessage.Content)
+	// 3. RAG Search on new message
+	emb, err := s.embedder.Embed(r.Context(), req.Message)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// 2. Search for relevant context
 	store, err := s.storeGetter(r.Context())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -299,7 +432,6 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// 3. Construct context string
 	var contextBuilder string
 	for _, rec := range records {
 		path := ""
@@ -316,36 +448,101 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// 4. Create system prompt
 	systemPrompt := "You are an expert AI coding assistant. Use the provided codebase context to answer the user's question. If the answer is not in the context, say so. \n\nContext:\n" + contextBuilder
 
-	// 5. Map messages to llm.Message
-	var llmMessages []llm.Message
-	for _, msg := range req.Messages {
-		llmMessages = append(llmMessages, llm.Message{
-			Role:    msg.Role,
-			Content: msg.Content,
-		})
+	// 4. Tools config
+	tools := []llm.Tool{
+		{
+			FunctionDeclarations: []llm.FunctionDeclaration{
+				{
+					Name:        "save_manual_context",
+					Description: "Saves client requirements, architectural rules, or manual notes to the vector database for future memory.",
+					Parameters: llm.Parameters{
+						Type: "OBJECT",
+						Properties: map[string]llm.Property{
+							"content": {
+								Type:        "STRING",
+								Description: "The formatted text to save",
+							},
+						},
+						Required: []string{"content"},
+					},
+				},
+			},
+		},
 	}
 
-	// 6. Call Gemini
-	// Allow overriding endpoint for testing
 	endpointURL := ""
 	if h := r.Header.Get("X-Test-Gemini-URL"); h != "" {
 		endpointURL = h
 	}
 
-	responseContent, err := llm.GenerateGeminiCompletion(r.Context(), s.cfg.GeminiApiKey, model, systemPrompt, llmMessages, endpointURL)
+	// 5. Call Gemini
+	resp, err := llm.GenerateGeminiCompletion(r.Context(), s.cfg.GeminiApiKey, model, systemPrompt, history.Messages, tools, endpointURL)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// 7. Return response
+	// 6. Handle Function Calling loop
+	if resp.FunctionCall != nil && resp.FunctionCall.Name == "save_manual_context" {
+		contentInter, ok := resp.FunctionCall.Args["content"]
+		if ok {
+			contentStr, _ := contentInter.(string)
+
+			// Save to LanceDB
+			emb, _ := s.embedder.Embed(r.Context(), contentStr)
+			meta := map[string]string{
+				"type":   "manual_context",
+				"source": "agentic_memory",
+			}
+			id := fmt.Sprintf("manual_%d", time.Now().UnixNano())
+			store.Insert(r.Context(), []db.Record{{
+				ID:        id,
+				Content:   contentStr,
+				Embedding: emb,
+				Metadata:  meta,
+			}})
+
+			// Append FunctionCall to history
+			fnCallMsg := llm.Message{
+				Role:         "assistant",
+				FunctionCall: resp.FunctionCall,
+			}
+			s.chatStore.AppendMessage(req.SessionID, fnCallMsg)
+			history.Messages = append(history.Messages, fnCallMsg)
+
+			// Append FunctionResponse to history
+			fnRespMsg := llm.Message{
+				Role: "function",
+				FunctionResponse: &llm.FunctionResponse{
+					Name: "save_manual_context",
+					Response: map[string]interface{}{
+						"status": "success",
+						"message": "Context saved successfully to Global Brain.",
+					},
+				},
+			}
+			s.chatStore.AppendMessage(req.SessionID, fnRespMsg)
+			history.Messages = append(history.Messages, fnRespMsg)
+
+			// Call Gemini again
+			resp, err = llm.GenerateGeminiCompletion(r.Context(), s.cfg.GeminiApiKey, model, systemPrompt, history.Messages, tools, endpointURL)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+		}
+	}
+
+	// 7. Append Assistant final message
+	assistantMsg := llm.Message{Role: "assistant", Content: resp.Text}
+	s.chatStore.AppendMessage(req.SessionID, assistantMsg)
+
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(ChatResponse{
 		ModelUsed: model,
 		Role:      "assistant",
-		Content:   responseContent,
+		Content:   resp.Text,
 	})
 }

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -26,14 +26,16 @@ func (m *mockEmbedder) Embed(ctx context.Context, text string) ([]float32, error
 
 // Better yet, let's just create a real temp db store for the test
 func setupTestServer(t *testing.T) (*Server, func()) {
+	tempDir := t.TempDir()
+
 	cfg := &config.Config{
 		ApiPort:            "8080",
 		Dimension:          1024,
 		GeminiApiKey:       "test-key",
 		DefaultGeminiModel: "gemini-test-model",
+		DataDir:            tempDir,
 	}
 
-	tempDir := t.TempDir()
 	store, err := db.Connect(context.Background(), tempDir, "test_collection")
 	if err != nil {
 		t.Fatalf("failed to connect to db: %v", err)
@@ -212,6 +214,14 @@ func TestChatEndpoint(t *testing.T) {
 	srv, cleanup := setupTestServer(t)
 	defer cleanup()
 
+	// 0. Create a session first
+	req0, _ := http.NewRequest("POST", "/api/sessions", bytes.NewReader([]byte(`{"title": "Test Chat"}`)))
+	rr0 := httptest.NewRecorder()
+	srv.srv.Handler.ServeHTTP(rr0, req0)
+	var sess map[string]interface{}
+	json.NewDecoder(rr0.Body).Decode(&sess)
+	sessionID := sess["id"].(string)
+
 	// 1. Insert dummy context
 	ctxReqBody := ContextRequest{
 		Text:   "The indexing worker processes files in the background.",
@@ -225,8 +235,12 @@ func TestChatEndpoint(t *testing.T) {
 	rr1 := httptest.NewRecorder()
 	srv.srv.Handler.ServeHTTP(rr1, req1)
 
+	callCount := 0
+
 	// 2. Setup mock Gemini server
 	mockGemini := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+
 		// Verify API Key
 		if r.URL.Query().Get("key") != "test-key" {
 			t.Errorf("expected API key 'test-key', got '%s'", r.URL.Query().Get("key"))
@@ -247,7 +261,23 @@ func TestChatEndpoint(t *testing.T) {
 			}
 		}
 
-		// Mock response
+		// First call: Simulate a function call
+		if callCount == 1 {
+			resp := `{
+				"candidates": [
+					{
+						"content": {
+							"parts": [{"functionCall": {"name": "save_manual_context", "args": {"content": "This is important to remember"}}}]
+						}
+					}
+				]
+			}`
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(resp))
+			return
+		}
+
+		// Second call: Return final text
 		resp := `{
 			"candidates": [
 				{
@@ -264,9 +294,8 @@ func TestChatEndpoint(t *testing.T) {
 
 	// 3. Make chat request
 	chatBody := ChatRequest{
-		Messages: []ChatMessage{
-			{Role: "user", Content: "How does the indexing worker work?"},
-		},
+		SessionID: sessionID,
+		Message:   "How does the indexing worker work?",
 	}
 	chatBytes, _ := json.Marshal(chatBody)
 	req2, _ := http.NewRequest("POST", "/api/chat", bytes.NewReader(chatBytes))
@@ -290,6 +319,16 @@ func TestChatEndpoint(t *testing.T) {
 	if resp.Content != "It processes files in the background." {
 		t.Errorf("expected generated content 'It processes files in the background.', got '%s'", resp.Content)
 	}
+
+	if callCount != 2 {
+		t.Errorf("expected Gemini to be called 2 times (function call + final text), got %d", callCount)
+	}
+
+	// 4. Verify context was saved to LanceDB
+	store, _ := srv.storeGetter(context.Background())
+	if store.Count() != 2 { // 1 initial context + 1 saved via function call
+		t.Errorf("expected 2 records in store (1 initial + 1 function call), got %d", store.Count())
+	}
 }
 
 func TestChatEndpointNoApiKey(t *testing.T) {
@@ -299,9 +338,8 @@ func TestChatEndpointNoApiKey(t *testing.T) {
 	srv.cfg.GeminiApiKey = "" // Unset API key
 
 	chatBody := ChatRequest{
-		Messages: []ChatMessage{
-			{Role: "user", Content: "Hello"},
-		},
+		SessionID: "dummy-id",
+		Message:   "Hello",
 	}
 	chatBytes, _ := json.Marshal(chatBody)
 	req, _ := http.NewRequest("POST", "/api/chat", bytes.NewReader(chatBytes))

--- a/internal/chat/store.go
+++ b/internal/chat/store.go
@@ -1,0 +1,170 @@
+package chat
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nilesh32236/vector-mcp-go/internal/llm"
+)
+
+type Session struct {
+	ID        string    `json:"id"`
+	Title     string    `json:"title"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type MessageHistory struct {
+	Session
+	Messages []llm.Message `json:"messages"`
+}
+
+type Store struct {
+	baseDir string
+	mu      sync.RWMutex
+}
+
+func NewStore(dataDir string) (*Store, error) {
+	baseDir := filepath.Join(dataDir, ".gemini", "chats")
+	if err := os.MkdirAll(baseDir, 0755); err != nil {
+		return nil, fmt.Errorf("failed to create chat directory: %w", err)
+	}
+	return &Store{
+		baseDir: baseDir,
+	}, nil
+}
+
+func (s *Store) getFilePath(id string) string {
+	return filepath.Join(s.baseDir, id+".json")
+}
+
+func (s *Store) CreateSession(title string) (Session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := uuid.New().String()
+	now := time.Now()
+
+	sess := Session{
+		ID:        id,
+		Title:     title,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	hist := MessageHistory{
+		Session:  sess,
+		Messages: []llm.Message{},
+	}
+
+	data, err := json.MarshalIndent(hist, "", "  ")
+	if err != nil {
+		return Session{}, fmt.Errorf("failed to marshal new session: %w", err)
+	}
+
+	if err := os.WriteFile(s.getFilePath(id), data, 0644); err != nil {
+		return Session{}, fmt.Errorf("failed to write session file: %w", err)
+	}
+
+	return sess, nil
+}
+
+func (s *Store) GetSession(id string) (MessageHistory, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	data, err := os.ReadFile(s.getFilePath(id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return MessageHistory{}, fmt.Errorf("session not found")
+		}
+		return MessageHistory{}, fmt.Errorf("failed to read session file: %w", err)
+	}
+
+	var hist MessageHistory
+	if err := json.Unmarshal(data, &hist); err != nil {
+		return MessageHistory{}, fmt.Errorf("failed to unmarshal session: %w", err)
+	}
+
+	return hist, nil
+}
+
+func (s *Store) ListSessions() ([]Session, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entries, err := os.ReadDir(s.baseDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read chat directory: %w", err)
+	}
+
+	var sessions []Session
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(s.baseDir, entry.Name()))
+		if err != nil {
+			continue // Skip unreadable files
+		}
+
+		var hist MessageHistory
+		if err := json.Unmarshal(data, &hist); err != nil {
+			continue // Skip malformed files
+		}
+
+		sessions = append(sessions, hist.Session)
+	}
+
+	return sessions, nil
+}
+
+func (s *Store) DeleteSession(id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	err := os.Remove(s.getFilePath(id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Already deleted
+		}
+		return fmt.Errorf("failed to delete session: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) AppendMessage(id string, msg llm.Message) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path := s.getFilePath(id)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read session file: %w", err)
+	}
+
+	var hist MessageHistory
+	if err := json.Unmarshal(data, &hist); err != nil {
+		return fmt.Errorf("failed to unmarshal session: %w", err)
+	}
+
+	hist.Messages = append(hist.Messages, msg)
+	hist.UpdatedAt = time.Now()
+
+	newData, err := json.MarshalIndent(hist, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal updated session: %w", err)
+	}
+
+	if err := os.WriteFile(path, newData, 0644); err != nil {
+		return fmt.Errorf("failed to write updated session file: %w", err)
+	}
+
+	return nil
+}

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -9,13 +9,63 @@ import (
 	"net/http"
 )
 
+type FunctionCall struct {
+	Name string                 `json:"name"`
+	Args map[string]interface{} `json:"args"`
+}
+
+type FunctionResponse struct {
+	Name     string                 `json:"name"`
+	Response map[string]interface{} `json:"response"`
+}
+
 type Message struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
+	Role             string            `json:"role"`
+	Content          string            `json:"content,omitempty"`
+	FunctionCall     *FunctionCall     `json:"function_call,omitempty"`
+	FunctionResponse *FunctionResponse `json:"function_response,omitempty"`
+}
+
+type CompletionResponse struct {
+	Text         string
+	FunctionCall *FunctionCall
+}
+
+type geminiFunctionCall struct {
+	FunctionName string                 `json:"name"`
+	Args         map[string]interface{} `json:"args"`
+}
+
+type geminiFunctionResponseContent struct {
+	Name     string                 `json:"name"`
+	Response map[string]interface{} `json:"response"`
 }
 
 type geminiPart struct {
-	Text string `json:"text"`
+	Text             string                         `json:"text,omitempty"`
+	FunctionCall     *geminiFunctionCall            `json:"functionCall,omitempty"`
+	FunctionResponse *geminiFunctionResponseContent `json:"functionResponse,omitempty"`
+}
+
+type Tool struct {
+	FunctionDeclarations []FunctionDeclaration `json:"function_declarations"`
+}
+
+type FunctionDeclaration struct {
+	Name        string     `json:"name"`
+	Description string     `json:"description"`
+	Parameters  Parameters `json:"parameters"`
+}
+
+type Parameters struct {
+	Type       string              `json:"type"`
+	Properties map[string]Property `json:"properties"`
+	Required   []string            `json:"required"`
+}
+
+type Property struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
 }
 
 type geminiContent struct {
@@ -30,20 +80,19 @@ type geminiSystemInstruction struct {
 type geminiRequest struct {
 	SystemInstruction *geminiSystemInstruction `json:"system_instruction,omitempty"`
 	Contents          []geminiContent          `json:"contents"`
+	Tools             []Tool                   `json:"tools,omitempty"`
 }
 
 type geminiResponse struct {
 	Candidates []struct {
 		Content struct {
-			Parts []struct {
-				Text string `json:"text"`
-			} `json:"parts"`
+			Parts []geminiPart `json:"parts"`
 		} `json:"content"`
 	} `json:"candidates"`
 }
 
 // GenerateGeminiCompletion calls the Google Gemini REST API to generate a response.
-func GenerateGeminiCompletion(ctx context.Context, apiKey string, model string, systemPrompt string, messages []Message, endpointURL string) (string, error) {
+func GenerateGeminiCompletion(ctx context.Context, apiKey string, model string, systemPrompt string, messages []Message, tools []Tool, endpointURL string) (CompletionResponse, error) {
 	if endpointURL == "" {
 		endpointURL = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", model)
 	}
@@ -58,30 +107,55 @@ func GenerateGeminiCompletion(ctx context.Context, apiKey string, model string, 
 		}
 	}
 
+	if len(tools) > 0 {
+		reqBody.Tools = tools
+	}
+
 	for _, msg := range messages {
 		// Gemini uses "user" and "model" roles
 		role := msg.Role
-		if role == "assistant" {
+		if role == "assistant" || role == "function" {
 			role = "model"
 		}
 
+		var parts []geminiPart
+
+		if msg.FunctionCall != nil {
+			parts = append(parts, geminiPart{
+				FunctionCall: &geminiFunctionCall{
+					FunctionName: msg.FunctionCall.Name,
+					Args:         msg.FunctionCall.Args,
+				},
+			})
+		} else if msg.FunctionResponse != nil {
+			role = "user" // Function responses are sent back as the user role in Gemini
+			parts = append(parts, geminiPart{
+				FunctionResponse: &geminiFunctionResponseContent{
+					Name:     msg.FunctionResponse.Name,
+					Response: msg.FunctionResponse.Response,
+				},
+			})
+		} else {
+			parts = append(parts, geminiPart{
+				Text: msg.Content,
+			})
+		}
+
 		reqBody.Contents = append(reqBody.Contents, geminiContent{
-			Role: role,
-			Parts: []geminiPart{
-				{Text: msg.Content},
-			},
+			Role:  role,
+			Parts: parts,
 		})
 	}
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal gemini request: %w", err)
+		return CompletionResponse{}, fmt.Errorf("failed to marshal gemini request: %w", err)
 	}
 
 	reqURL := fmt.Sprintf("%s?key=%s", endpointURL, apiKey)
 	req, err := http.NewRequestWithContext(ctx, "POST", reqURL, bytes.NewBuffer(jsonData))
 	if err != nil {
-		return "", fmt.Errorf("failed to create http request: %w", err)
+		return CompletionResponse{}, fmt.Errorf("failed to create http request: %w", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -89,23 +163,36 @@ func GenerateGeminiCompletion(ctx context.Context, apiKey string, model string, 
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("failed to execute http request: %w", err)
+		return CompletionResponse{}, fmt.Errorf("failed to execute http request: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("gemini api returned status %d: %s", resp.StatusCode, string(bodyBytes))
+		return CompletionResponse{}, fmt.Errorf("gemini api returned status %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
 	var geminiResp geminiResponse
 	if err := json.NewDecoder(resp.Body).Decode(&geminiResp); err != nil {
-		return "", fmt.Errorf("failed to decode gemini response: %w", err)
+		return CompletionResponse{}, fmt.Errorf("failed to decode gemini response: %w", err)
 	}
 
 	if len(geminiResp.Candidates) == 0 || len(geminiResp.Candidates[0].Content.Parts) == 0 {
-		return "", fmt.Errorf("gemini api returned no content")
+		return CompletionResponse{}, fmt.Errorf("gemini api returned no content")
 	}
 
-	return geminiResp.Candidates[0].Content.Parts[0].Text, nil
+	part := geminiResp.Candidates[0].Content.Parts[0]
+
+	comp := CompletionResponse{}
+
+	if part.FunctionCall != nil {
+		comp.FunctionCall = &FunctionCall{
+			Name: part.FunctionCall.FunctionName,
+			Args: part.FunctionCall.Args,
+		}
+	} else {
+		comp.Text = part.Text
+	}
+
+	return comp, nil
 }


### PR DESCRIPTION
- Created internal/chat/store.go for file-based JSON storage of chat sessions.
- Added API endpoints for session CRUD: GET /api/sessions, POST /api/sessions, GET /api/sessions/{id}, DELETE /api/sessions/{id}.
- Updated POST /api/chat to require session_id and maintain conversation history in the JSON store.
- Updated the RAG workflow to only embed the user's latest message for LanceDB codebase context retrieval, while forwarding the full conversation history to Gemini.
- Expanded internal/llm/gemini.go to support Gemini Function Calling via the `tools` payload and `functionCall`/`functionResponse` message roles.
- Granted the Gemini LLM 'Agentic Memory' by exposing a `save_manual_context` tool. When invoked by the model, the backend automatically embeds the payload and inserts it into LanceDB before continuing the conversation loop.
- Added unit tests for the Chat API to mock the two-step function calling loop and verify database side-effects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Session-based chat system: Create, manage, and maintain separate chat conversations with persistent message history.
  * Context-aware responses: Integrated retrieval-augmented generation to provide responses informed by relevant context.
  * Smart context saving: System can automatically save content to the vector store during conversations for enhanced response quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->