### PR TITLE
Refactor MCP Tools: Consolidate Search, Generalize Docstrings, Refine Dead Code Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,12 @@ export ONNX_LIB_PATH="/custom/path/to/libonnxruntime.so"
 | `find_duplicate_code`     | Scan for logic duplication across namespaces.                                                                     |
 | `get_codebase_skeleton`   | View a topological tree of the project structure.                                                                 |
 | `index_status`            | Monitor indexing progress and database health.                                                                    |
-| `retrieve_context`        | Perform semantic search across the codebase using natural language.                                               |
+| `search_codebase`         | Unified semantic and lexical search across the codebase. Replaces retrieve_context and retrieve_docs.             |
 | `delete_context`          | Remove specific files or wipe entire project indices.                                                             |
 | `check_dependency_health` | Analyzes a directory's package.json against its indexed imports to identify missing dependencies in the manifest. |
-| `generate_jsdoc_prompt`   | Generates a highly contextual prompt for an LLM to write professional JSDoc for a specific entity.                |
+| `generate_docstring_prompt`| Generates a highly contextual prompt for an LLM to write professional documentation for a specific entity, with optional language support. |
 | `analyze_architecture`    | Generates a Mermaid.js dependency graph between packages in a monorepo.                                           |
-| `find_dead_code`          | Identifies potentially dead code by finding exported symbols that are never imported or called.                   |
+| `find_dead_code`          | Identifies potentially dead code by finding exported symbols that are never imported or called. Supports exclusion paths and library mode. |
 
 ---
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -75,6 +75,8 @@ func NewServer(cfg *config.Config, logger *slog.Logger, storeGetter func(ctx con
 	return srv
 }
 
+// WithRemoteStore configures the server to use a remote IndexerStore
+// instead of dynamically fetching a local store on every request.
 func (s *Server) WithRemoteStore(rs IndexerStore) {
 	s.remoteStore = rs
 }
@@ -1408,6 +1410,8 @@ func (s *Server) runStatus(ctx context.Context, store IndexerStore) (string, err
 	return out.String(), nil
 }
 
+// CallTool allows programmatic execution of a registered tool by its name.
+// It bypasses the standard MCP protocol layers for internal API usage.
 func (s *Server) CallTool(ctx context.Context, name string, args map[string]interface{}) (*mcp.CallToolResult, error) {
 	handler, ok := s.toolHandlers[name]
 	if !ok {
@@ -1422,6 +1426,7 @@ func (s *Server) CallTool(ctx context.Context, name string, args map[string]inte
 	return handler(ctx, req)
 }
 
+// ListTools returns all tools currently registered on the server.
 func (s *Server) ListTools() []mcp.Tool {
 	var tools []mcp.Tool
 	for _, t := range s.MCPServer.ListTools() {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -149,28 +149,6 @@ func (s *Server) registerTools() {
 	addTool(mcp.NewTool("index_status", mcp.WithDescription("Check index status and background progress. Use this to verify if the server is still indexing or if it's ready for queries.")),
 		s.handleIndexStatus)
 
-	// 5.5 retrieve_context
-	addTool(mcp.NewTool("retrieve_context",
-		mcp.WithDescription("Semantic search across the indexed codebase using natural language. Returns the most relevant code chunks."),
-		mcp.WithString("query", mcp.Description("The natural language search query")),
-		mcp.WithNumber("topK", mcp.Description("Number of results to return (default 5)")),
-		mcp.WithArray("cross_reference_projects",
-			mcp.Description("Optional list of project IDs to search across"),
-			mcp.WithStringItems(),
-		),
-	), s.handleRetrieveContext)
-
-	// 5.6 retrieve_docs
-	addTool(mcp.NewTool("retrieve_docs",
-		mcp.WithDescription("Semantic search across the indexed documentation (PDFs, MDs, TXTs) using natural language."),
-		mcp.WithString("query", mcp.Description("The natural language search query")),
-		mcp.WithNumber("topK", mcp.Description("Number of results to return (default 5)")),
-		mcp.WithArray("cross_reference_projects",
-			mcp.Description("Optional list of project IDs to search across"),
-			mcp.WithStringItems(),
-		),
-	), s.handleRetrieveDocs)
-
 	// 6. get_codebase_skeleton
 	addTool(mcp.NewTool("get_codebase_skeleton",
 		mcp.WithDescription("Returns a topological tree map of the directory structure. Use this to progressively explore large codebases by specifying sub-directories and depths."),
@@ -187,12 +165,13 @@ func (s *Server) registerTools() {
 		mcp.WithString("directory_path", mcp.Description("The path to the directory containing package.json and source files")),
 	), s.handleCheckDependencyHealth)
 
-	// 8. generate_jsdoc_prompt
-	addTool(mcp.NewTool("generate_jsdoc_prompt",
-		mcp.WithDescription("Generates a highly contextual prompt for an LLM to write professional JSDoc for a specific entity."),
+	// 8. generate_docstring_prompt
+	addTool(mcp.NewTool("generate_docstring_prompt",
+		mcp.WithDescription("Generates a highly contextual prompt for an LLM to write professional documentation for a specific entity."),
 		mcp.WithString("file_path", mcp.Description("The relative path of the file")),
 		mcp.WithString("entity_name", mcp.Description("The name of the function or class to document")),
-	), s.handleGenerateJSDocPrompt)
+		mcp.WithString("language", mcp.Description("Optional: The language of the file (e.g., 'Go', 'TypeScript', 'Python'). Extracted from file extension if omitted.")),
+	), s.handleGenerateDocstringPrompt)
 
 	// 9. analyze_architecture
 	addTool(mcp.NewTool("analyze_architecture",
@@ -203,6 +182,8 @@ func (s *Server) registerTools() {
 	// 10. find_dead_code
 	addTool(mcp.NewTool("find_dead_code",
 		mcp.WithDescription("Identifies potentially dead code by finding exported symbols that are never imported or called."),
+		mcp.WithArray("exclude_paths", mcp.Description("Optional list of file paths or patterns to exclude from dead code analysis."), mcp.WithStringItems()),
+		mcp.WithBoolean("is_library", mcp.Description("Optional: Set to true if analyzing a library where public exports are expected. Only flags unused symbols inside internal/ or marked as private.")),
 	), s.handleFindDeadCode)
 
 	// 11. filesystem_grep
@@ -215,9 +196,9 @@ func (s *Server) registerTools() {
 
 	// 12. search_codebase
 	addTool(mcp.NewTool("search_codebase",
-		mcp.WithDescription("Unified semantic and lexical search across the codebase with advanced filtering."),
+		mcp.WithDescription("Unified semantic and lexical search across the codebase. Replaces retrieve_context and retrieve_docs."),
 		mcp.WithString("query", mcp.Description("The natural language search query")),
-		mcp.WithString("category", mcp.Description("Optional: 'code' or 'document'. Defaults to searching both.")),
+		mcp.WithString("category", mcp.Description("Optional: 'code' or 'document'. Handles both 'code' and 'document' retrieval. Defaults to searching both.")),
 		mcp.WithNumber("topK", mcp.Description("Number of results to return (default 10)")),
 		mcp.WithString("path_filter", mcp.Description("Optional: Only search files whose path contains this string")),
 		mcp.WithNumber("min_score", mcp.Description("Optional: Minimum similarity score (0.0 to 1.0) to include a result")),
@@ -625,124 +606,6 @@ func (s *Server) handleIndexStatus(ctx context.Context, request mcp.CallToolRequ
 	return mcp.NewToolResultText(res + bgStatus), nil
 }
 
-func (s *Server) handleRetrieveContext(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	query := request.GetString("query", "")
-	if query == "" {
-		return mcp.NewToolResultError("query is required"), nil
-	}
-	topK := int(request.GetFloat("topK", 5))
-
-	pids := request.GetStringSlice("cross_reference_projects", nil)
-	if len(pids) == 0 {
-		pids = []string{s.cfg.ProjectRoot}
-	}
-
-	emb, err := s.embedder.Embed(ctx, query)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to embed query: %v", err)), nil
-	}
-
-	store, err := s.getStore(ctx)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to get store: %v", err)), nil
-	}
-
-	results, err := store.HybridSearch(ctx, query, emb, topK, pids, "code")
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to search database: %v", err)), nil
-	}
-
-	if len(results) == 0 {
-		return mcp.NewToolResultText("No relevant context found."), nil
-	}
-
-	var out strings.Builder
-	out.WriteString("### Hybrid Search Results (Lexical + Semantic):\n\n")
-	currentTokenCount := 0
-
-	for i, r := range results {
-		tokens := indexer.EstimateTokens(r.Content)
-		if currentTokenCount+tokens > indexer.MaxContextTokens {
-			out.WriteString("... (truncating further results to stay within context window)")
-			break
-		}
-
-		lineRange := ""
-		if start, ok := r.Metadata["start_line"]; ok {
-			if end, ok := r.Metadata["end_line"]; ok {
-				lineRange = fmt.Sprintf(" (Lines %s-%s)", start, end)
-			}
-		}
-
-		out.WriteString(fmt.Sprintf("#### Result %d: %s%s\n", i+1, r.Metadata["path"], lineRange))
-		if syms := r.Metadata["symbols"]; syms != "" {
-			out.WriteString(fmt.Sprintf("- **Entities**: %s\n", syms))
-		}
-		if rels := r.Metadata["relationships"]; rels != "" {
-			out.WriteString(fmt.Sprintf("- **Relationships**: %s\n", rels))
-		}
-		out.WriteString(fmt.Sprintf("```\n%s\n```\n\n", r.Content))
-		currentTokenCount += tokens
-	}
-	return mcp.NewToolResultText(out.String()), nil
-}
-
-func (s *Server) handleRetrieveDocs(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	query := request.GetString("query", "")
-	if query == "" {
-		return mcp.NewToolResultError("query is required"), nil
-	}
-	topK := int(request.GetFloat("topK", 5))
-
-	pids := request.GetStringSlice("cross_reference_projects", nil)
-	if len(pids) == 0 {
-		pids = []string{s.cfg.ProjectRoot}
-	}
-
-	emb, err := s.embedder.Embed(ctx, query)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to embed query: %v", err)), nil
-	}
-
-	store, err := s.getStore(ctx)
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to get store: %v", err)), nil
-	}
-
-	results, err := store.HybridSearch(ctx, query, emb, topK, pids, "document")
-	if err != nil {
-		return mcp.NewToolResultError(fmt.Sprintf("Failed to search database: %v", err)), nil
-	}
-
-	if len(results) == 0 {
-		return mcp.NewToolResultText("No relevant context found."), nil
-	}
-
-	var out strings.Builder
-	out.WriteString("### Document Search Results:\n\n")
-	currentTokenCount := 0
-
-	for i, r := range results {
-		tokens := indexer.EstimateTokens(r.Content)
-		if currentTokenCount+tokens > indexer.MaxContextTokens {
-			out.WriteString("... (truncating further results to stay within context window)")
-			break
-		}
-
-		lineRange := ""
-		if start, ok := r.Metadata["start_line"]; ok {
-			if end, ok := r.Metadata["end_line"]; ok {
-				lineRange = fmt.Sprintf(" (Lines %s-%s)", start, end)
-			}
-		}
-
-		out.WriteString(fmt.Sprintf("#### Result %d: %s%s\n", i+1, r.Metadata["path"], lineRange))
-		out.WriteString(fmt.Sprintf("```\n%s\n```\n\n", r.Content))
-		currentTokenCount += tokens
-	}
-	return mcp.NewToolResultText(out.String()), nil
-}
-
 func (s *Server) handleGetCodebaseSkeleton(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
@@ -986,11 +849,35 @@ func (s *Server) handleCheckDependencyHealth(ctx context.Context, request mcp.Ca
 	return mcp.NewToolResultText(out.String()), nil
 }
 
-func (s *Server) handleGenerateJSDocPrompt(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleGenerateDocstringPrompt(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	filePath := request.GetString("file_path", "")
 	entityName := request.GetString("entity_name", "")
+	language := request.GetString("language", "")
+
 	if filePath == "" || entityName == "" {
 		return mcp.NewToolResultError("file_path and entity_name are required"), nil
+	}
+
+	if language == "" {
+		ext := strings.ToLower(filepath.Ext(filePath))
+		switch ext {
+		case ".go":
+			language = "Go"
+		case ".ts", ".js", ".tsx", ".jsx":
+			language = "TypeScript/JavaScript"
+		case ".py":
+			language = "Python"
+		}
+	}
+
+	docStyle := "professional documentation comment"
+	switch strings.ToLower(language) {
+	case "go":
+		docStyle = "Godoc comments"
+	case "typescript/javascript", "typescript", "javascript", "ts", "js":
+		docStyle = "JSDoc comments"
+	case "python":
+		docStyle = "Python docstrings (PEP 257 format)"
 	}
 
 	store, err := s.getStore(ctx)
@@ -1032,14 +919,14 @@ func (s *Server) handleGenerateJSDocPrompt(ctx context.Context, request mcp.Call
 	symbols := match.Metadata["symbols"]
 	relationships := match.Metadata["relationships"]
 
-	prompt := fmt.Sprintf(`Please write a professional JSDoc comment for the following code. 
+	prompt := fmt.Sprintf(`Please write a professional %s for the following code.
 Architecture Context:
 - Entity: %s
 - Internal Calls made: %s
 - File Imports: %s
 
 Code:
-%s`, symbols, calls, relationships, content)
+%s`, docStyle, symbols, calls, relationships, content)
 
 	return mcp.NewToolResultText(prompt), nil
 }
@@ -1117,7 +1004,34 @@ func (s *Server) handleAnalyzeArchitecture(ctx context.Context, request mcp.Call
 	return mcp.NewToolResultText(sb.String()), nil
 }
 
-func (s *Server) handleFindDeadCode(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+func (s *Server) handleFindDeadCode(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	var excludePaths []string
+	hasExcludePaths := false
+	if args, ok := request.Params.Arguments.(map[string]interface{}); ok {
+		if rawPaths, ok := args["exclude_paths"].([]interface{}); ok {
+			hasExcludePaths = true
+			for _, p := range rawPaths {
+				if strP, ok := p.(string); ok {
+					excludePaths = append(excludePaths, strP)
+				}
+			}
+		} else if request.GetStringSlice("exclude_paths", nil) != nil {
+			hasExcludePaths = true
+			excludePaths = request.GetStringSlice("exclude_paths", nil)
+		}
+	}
+
+	if !hasExcludePaths {
+		excludePaths = []string{"/api", "/routes", "/cmd", "main.go", "index.ts"}
+	}
+
+	isLibrary := false
+	if args, ok := request.Params.Arguments.(map[string]interface{}); ok {
+		if val, exists := args["is_library"].(bool); exists {
+			isLibrary = val
+		}
+	}
+
 	store, err := s.getStore(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(err.Error()), nil
@@ -1136,14 +1050,36 @@ func (s *Server) handleFindDeadCode(ctx context.Context, _ mcp.CallToolRequest) 
 	setB := make(map[string]bool)           // name -> used
 
 	for _, r := range records {
+		filePath := r.Metadata["path"]
+
+		isExcluded := false
+		if !isLibrary {
+			for _, ep := range excludePaths {
+				if strings.Contains(filePath, ep) {
+					isExcluded = true
+					break
+				}
+			}
+		}
+
+		// If library, only consider internal/ or explicitly private
+		if isLibrary {
+			isInternal := strings.Contains(filePath, "internal/") || strings.Contains(filePath, "private/") || strings.HasPrefix(filepath.Base(filePath), "_")
+			if !isInternal {
+				isExcluded = true
+			}
+		}
+
 		// Set A: Exports (structural types only)
 		t := r.Metadata["type"]
-		if t == "function" || t == "class" || t == "variable" || t == "arrow_function" {
+		if !isExcluded && (t == "function" || t == "class" || t == "variable" || t == "arrow_function") {
 			var syms []string
 			if err := json.Unmarshal([]byte(r.Metadata["symbols"]), &syms); err == nil {
 				for _, sym := range syms {
 					if sym != "" {
-						setA[sym] = exportedSymbol{name: sym, path: r.Metadata["path"]}
+						// For libraries, if symbol starts with uppercase (Go) or isn't starting with _, it's public.
+						// Wait, if it's in internal/ it's already filtered above, but let's check if there are other rules
+						setA[sym] = exportedSymbol{name: sym, path: filePath}
 					}
 				}
 			}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -88,9 +88,9 @@ func TestIndexStatusTool(t *testing.T) {
 	}
 }
 
-func TestRetrieveContextTool(t *testing.T) {
+func TestSearchCodebaseTool(t *testing.T) {
 	ctx := context.Background()
-	dbPath := "./test_retrieve_db"
+	dbPath := "./test_search_db"
 	os.RemoveAll(dbPath)
 	defer os.RemoveAll(dbPath)
 
@@ -140,14 +140,14 @@ func TestRetrieveContextTool(t *testing.T) {
 
 	// Test with query
 	req := mcp.CallToolRequest{}
-	req.Params.Name = "retrieve_context"
+	req.Params.Name = "search_codebase"
 	req.Params.Arguments = map[string]interface{}{
 		"query": "hello world",
 	}
 
-	res, err := srv.handleRetrieveContext(ctx, req)
+	res, err := srv.handleSearchCodebase(ctx, req)
 	if err != nil {
-		t.Fatalf("HandleRetrieveContext failed: %v", err)
+		t.Fatalf("HandleSearchCodebase failed: %v", err)
 	}
 
 	content := res.Content[0].(mcp.TextContent).Text
@@ -277,19 +277,22 @@ export class SharedUtils {
 		}
 	})
 
-	t.Run("GenerateJSDocPrompt", func(t *testing.T) {
+	t.Run("GenerateDocstringPrompt", func(t *testing.T) {
 		req := mcp.CallToolRequest{}
 		req.Params.Arguments = map[string]interface{}{
 			"file_path":   "apps/api/main.ts",
 			"entity_name": "aliveFn",
 		}
-		res, err := srv.handleGenerateJSDocPrompt(ctx, req)
+		res, err := srv.handleGenerateDocstringPrompt(ctx, req)
 		if err != nil {
 			t.Fatal(err)
 		}
 		content := res.Content[0].(mcp.TextContent).Text
 		if !strings.Contains(content, "SharedUtils") || !strings.Contains(content, "aliveFn") {
 			t.Errorf("expected architectural context in prompt, got: %s", content)
+		}
+		if !strings.Contains(content, "JSDoc comments") {
+			t.Errorf("expected JSDoc comments to be requested based on file extension, got: %s", content)
 		}
 	})
 
@@ -309,7 +312,11 @@ export class SharedUtils {
 	})
 
 	t.Run("FindDeadCode", func(t *testing.T) {
-		res, err := srv.handleFindDeadCode(ctx, mcp.CallToolRequest{})
+		req := mcp.CallToolRequest{}
+		req.Params.Arguments = map[string]interface{}{
+			"exclude_paths": []string{},
+		}
+		res, err := srv.handleFindDeadCode(ctx, req)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/skills/vector-context/SKILL.md
+++ b/skills/vector-context/SKILL.md
@@ -26,7 +26,8 @@ When starting work on a new project, always check the index status and trigger a
 ### 2. Implementation Context
 Before modifying a file, retrieve its full semantic context:
 1. `get_related_context(filePath)`: Get chunked code, imports, and resolved local dependencies.
-2. This provides much more depth than just reading the file content directly.
+2. `search_codebase(query)`: Search for specific functions, components, or concepts across the codebase.
+3. This provides much more depth than just reading the file content directly.
 
 ### 3. Refactoring and Optimization
 Use the duplication tool to find consolidation opportunities:
@@ -35,10 +36,11 @@ Use the duplication tool to find consolidation opportunities:
 ### 4. Knowledge Sharing
 Maintain technical debt or architectural records:
 1. `store_context(text)`: Record a decision (e.g., "Use Tailwind for all new components").
-2. This information persists and can be retrieved via semantic search later.
+2. This information persists and can be retrieved via `search_codebase` later.
 
 ## 💡 Best Practices
 
 - **Absolute Paths**: Always use absolute paths for `project_path` and `filePath`.
 - **Top-K Tuning**: Use semantic search with a reasonable `topK` (default is 5) to balance breadth and token usage.
 - **Dynamic Updates**: If you make major structural changes, call `trigger_project_index` to ensure your search results remain accurate.
+- **Context Window Awareness**: When using `search_codebase`, always pay attention to the `max_tokens` limit. If your search results are truncated, fallback to using `filesystem_grep` to narrow down the exact file or line numbers.


### PR DESCRIPTION
Implemented tasks to refine the `vector-mcp-go` server tools and agent instructions:
1. Consolidate Search Tools: Removed `retrieve_context` and `retrieve_docs` and updated `search_codebase` description to highlight its unified role.
2. Generalize Docstring Generation: Renamed `generate_jsdoc_prompt` to `generate_docstring_prompt`, added `language` parameter, and updated prompt to handle Go, TypeScript/JavaScript, and Python specific formats.
3. Refine Dead Code Analysis: Added `exclude_paths` and `is_library` arguments to `find_dead_code` to prevent flagging entry points or to scope analysis for libraries.
4. Update Agent Instructions: Updated `skills/vector-context/SKILL.md` and `README.md` to reflect tool changes and add Context Window Awareness advice.

---
*PR created automatically by Jules for task [5724042286530458221](https://jules.google.com/task/5724042286530458221) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Unified codebase search tool combining semantic and lexical search capabilities
  - Docstring generation now supports language-specific formatting

* **Improvements**
  - Dead code detection enhanced with exclusion patterns and library mode support

* **Documentation**
  - Updated codebase search workflow guidance in implementation context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->