### PR TITLE
🧹 [Code Health] Fix unhandled error from rpc.RegisterName

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -330,7 +330,9 @@ func StartMasterServer(socketPath string, embedder indexer.Embedder, indexQueue 
 	// rpc.RegisterName is global for the default server.
 	// Since we only ever have one MasterServer in a process, we can register it once.
 	// However, to support updating the embedder later, we use a service pointer.
-	_ = rpc.RegisterName("VectorDaemon", svc)
+	if err := rpc.RegisterName("VectorDaemon", svc); err != nil {
+		return nil, fmt.Errorf("failed to register RPC service: %w", err)
+	}
 
 	// Check if a master is already listening on the socket before removing it.
 	if conn, err := net.DialTimeout("unix", socketPath, time.Second); err == nil {


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The `rpc.RegisterName` function returns an error if the service name is already registered or if the type is invalid. This error was being ignored with a blank identifier `_`.

💡 **Why:** How this improves maintainability
Handling this error ensures that if registration fails for any reason, the `StartMasterServer` function fails early and explicitly, rather than failing silently and potentially causing confusing issues later when clients attempt to connect.

✅ **Verification:** How you confirmed the change is safe
Ran `go build ./...` and `go test ./...` which compile successfully and run correctly.
The function `StartMasterServer` already returns an error, so no existing code references to it needed to be updated.

✨ **Result:** The improvement achieved
A clear error is returned if RPC service registration fails.

---
*PR created automatically by Jules for task [17642560772386311552](https://jules.google.com/task/17642560772386311552) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The daemon now properly reports RPC service registration failures during startup instead of silently proceeding, enabling faster diagnosis of configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->