### PR TITLE
🧪 [Add tests for stripJSONC in workspace resolver]

### DIFF
--- a/internal/indexer/resolver.go
+++ b/internal/indexer/resolver.go
@@ -53,8 +53,14 @@ func stripJSONC(input string) string {
 			continue
 		}
 
-		if r == '"' && (i == 0 || runes[i-1] != '\\') {
-			inString = !inString
+		if r == '"' {
+			backslashes := 0
+			for j := i - 1; j >= 0 && runes[j] == '\\'; j-- {
+				backslashes++
+			}
+			if backslashes%2 == 0 {
+				inString = !inString
+			}
 		}
 
 		if !inString {

--- a/internal/indexer/resolver_test.go
+++ b/internal/indexer/resolver_test.go
@@ -1,0 +1,83 @@
+package indexer
+
+import (
+	"testing"
+)
+
+func TestStripJSONC(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no comments",
+			input:    `{"a": 1}`,
+			expected: `{"a": 1}`,
+		},
+		{
+			name:     "line comment with newline",
+			input:    `{"a": 1} // comment` + "\n" + `{"b": 2}`,
+			expected: `{"a": 1} ` + "\n" + `{"b": 2}`,
+		},
+		{
+			name:     "line comment without trailing newline",
+			input:    `{"a": 1} // comment`,
+			expected: `{"a": 1} `,
+		},
+		{
+			name:     "block comment",
+			input:    `{"a": 1} /* comment */`,
+			expected: `{"a": 1} `,
+		},
+		{
+			name:     "multi-line block comment",
+			input:    "/* multi\nline\n*/{\"a\": 1}",
+			expected: `{"a": 1}`,
+		},
+		{
+			name:     "URL in string",
+			input:    `{"url": "http://example.com"}`,
+			expected: `{"url": "http://example.com"}`,
+		},
+		{
+			name:     "block comment syntax in string",
+			input:    `{"text": "/* not a comment */"}`,
+			expected: `{"text": "/* not a comment */"}`,
+		},
+		{
+			name:     "escaped quote in string",
+			input:    `{"text": "\"// not a comment\""}`,
+			expected: `{"text": "\"// not a comment\""}`,
+		},
+		{
+			name:     "empty string",
+			input:    ``,
+			expected: ``,
+		},
+		{
+			name:     "only line comment",
+			input:    `// only comment`,
+			expected: ``,
+		},
+		{
+			name:     "escaped backslash before quote",
+			input:    `{"text": "\\"} // comment`,
+			expected: `{"text": "\\"} `,
+		},
+		{
+			name:     "multiple comments",
+			input:    `{ // comment 1` + "\n" + `/* comment 2 */ "a": 1 }`,
+			expected: `{ ` + "\n" + ` "a": 1 }`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripJSONC(tt.input)
+			if got != tt.expected {
+				t.Errorf("stripJSONC(%q) = %q; want %q", tt.input, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🎯 **What:** The untested private function `stripJSONC` in `internal/indexer/resolver.go` lacked test coverage. This function strips comments from JSON strings. During testing, a bug was found regarding handling escaped backslashes immediately before quotes (e.g., `{"key": "\\"}`).

📊 **Coverage:** Added comprehensive table-driven tests covering normal JSON, line comments (`//`), block comments (`/* */`), URLs in strings, block comment syntax in strings, escaped quotes in strings, empty strings, and multiple comments combinations. Added logic to correctly handle sequences of escaped backslashes before quotes.

✨ **Result:** Test coverage for `internal/indexer/resolver.go` is established, specifically for `stripJSONC`. The function's logic is now more robust against edge cases with string escapes.

---
*PR created automatically by Jules for task [12423269535503902718](https://jules.google.com/task/12423269535503902718) started by @nilesh32236*