### PR TITLE
🧹 [Code Health] Improve error handling for os.Remove in socket cleanup

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/rpc"
 	"os"
@@ -336,7 +337,9 @@ func StartMasterServer(socketPath string, embedder indexer.Embedder, indexQueue 
 		return nil, fmt.Errorf("master already running on %s", socketPath)
 	}
 	// Socket exists but is stale (no one listening) — safe to remove.
-	_ = os.Remove(socketPath)
+	if err := os.Remove(socketPath); err != nil && !os.IsNotExist(err) {
+		slog.Warn("Failed to remove stale socket file", "path", socketPath, "error", err)
+	}
 
 	l, err := net.Listen("unix", socketPath)
 	if err != nil {
@@ -376,7 +379,9 @@ func (s *MasterServer) Close() {
 	if s.listener != nil {
 		s.listener.Close()
 	}
-	_ = os.Remove(s.socketPath)
+	if err := os.Remove(s.socketPath); err != nil && !os.IsNotExist(err) {
+		slog.Warn("Failed to remove socket file on close", "path", s.socketPath, "error", err)
+	}
 }
 
 // Client facilitates communication from Slave to Master.

--- a/internal/mcp/handlers_analysis.go
+++ b/internal/mcp/handlers_analysis.go
@@ -16,6 +16,7 @@ import (
 	"github.com/nilesh32236/vector-mcp-go/internal/config"
 	"github.com/nilesh32236/vector-mcp-go/internal/db"
 	"github.com/nilesh32236/vector-mcp-go/internal/indexer"
+	"github.com/nilesh32236/vector-mcp-go/internal/llm"
 )
 
 // handleGetRelatedContext retrieves relevant code chunks and dependencies for a given file.
@@ -962,7 +963,7 @@ func (s *Server) handleListAPIEndpoints(ctx context.Context, request mcp.CallToo
 
 	// We look for common routing keywords
 	keywords := []string{"HandleFunc", "mux.Handle", "app.GET", "app.POST", "router.Register", "Route(", "@app.route", "FastAPI()"}
-	
+
 	var allMatches []db.Record
 	for _, kw := range keywords {
 		matches, _ := store.LexicalSearch(ctx, kw, 20, []string{s.cfg.ProjectRoot}, "code")
@@ -982,7 +983,7 @@ func (s *Server) handleListAPIEndpoints(ctx context.Context, request mcp.CallToo
 
 	var out strings.Builder
 	out.WriteString("## 🌐 Detected API Endpoints / Routes\n\n")
-	
+
 	paths := make([]string, 0, len(uniqueMatches))
 	for k := range uniqueMatches {
 		paths = append(paths, k)


### PR DESCRIPTION
🎯 What: Handled errors returned by `os.Remove` when trying to clean up stale socket files in `StartMasterServer` and `Close`. Unrelated fix in `internal/mcp/handlers_analysis.go` for missing `internal/llm` import.
💡 Why: Adds logging warnings when `os.Remove` fails, but not when it fails because the file does not exist, improving operational visibility. Unrelated fix was necessary for tests to pass.
✅ Verification: Ran `go test ./...` and `go build ./...` successfully.
✨ Result: `os.Remove`'s return is properly handled by checking the returned error and using `log/slog` to record a warning.

---
*PR created automatically by Jules for task [5599207325506683877](https://jules.google.com/task/5599207325506683877) started by @nilesh32236*