### PR TITLE
🧹 Refactor GenerateGeminiCompletion parameters into a struct

### DIFF
--- a/internal/api/handlers_chat.go
+++ b/internal/api/handlers_chat.go
@@ -291,7 +291,14 @@ func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
 	var i int
 	maxTurns := 10
 	for i = 0; i < maxTurns; i++ {
-		resp, err := llm.GenerateGeminiCompletion(r.Context(), s.cfg.GeminiApiKey, model, systemPrompt, history.Messages, geminiTools, endpointURL)
+		resp, err := llm.GenerateGeminiCompletion(r.Context(), llm.GeminiConfig{
+			APIKey:       s.cfg.GeminiApiKey,
+			Model:        model,
+			SystemPrompt: systemPrompt,
+			Messages:     history.Messages,
+			Tools:        geminiTools,
+			EndpointURL:  endpointURL,
+		})
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/internal/llm/gemini.go
+++ b/internal/llm/gemini.go
@@ -91,27 +91,38 @@ type geminiResponse struct {
 	} `json:"candidates"`
 }
 
+// GeminiConfig holds the configuration for a Gemini completion request.
+type GeminiConfig struct {
+	APIKey       string
+	Model        string
+	SystemPrompt string
+	Messages     []Message
+	Tools        []Tool
+	EndpointURL  string
+}
+
 // GenerateGeminiCompletion calls the Google Gemini REST API to generate a response.
-func GenerateGeminiCompletion(ctx context.Context, apiKey string, model string, systemPrompt string, messages []Message, tools []Tool, endpointURL string) (CompletionResponse, error) {
+func GenerateGeminiCompletion(ctx context.Context, cfg GeminiConfig) (CompletionResponse, error) {
+	endpointURL := cfg.EndpointURL
 	if endpointURL == "" {
-		endpointURL = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", model)
+		endpointURL = fmt.Sprintf("https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent", cfg.Model)
 	}
 
 	reqBody := geminiRequest{}
 
-	if systemPrompt != "" {
+	if cfg.SystemPrompt != "" {
 		reqBody.SystemInstruction = &geminiSystemInstruction{
 			Parts: []geminiPart{
-				{Text: systemPrompt},
+				{Text: cfg.SystemPrompt},
 			},
 		}
 	}
 
-	if len(tools) > 0 {
-		reqBody.Tools = tools
+	if len(cfg.Tools) > 0 {
+		reqBody.Tools = cfg.Tools
 	}
 
-	for _, msg := range messages {
+	for _, msg := range cfg.Messages {
 		// Gemini uses "user" and "model" roles
 		role := msg.Role
 		if role == "assistant" || role == "function" {
@@ -152,7 +163,7 @@ func GenerateGeminiCompletion(ctx context.Context, apiKey string, model string, 
 		return CompletionResponse{}, fmt.Errorf("failed to marshal gemini request: %w", err)
 	}
 
-	reqURL := fmt.Sprintf("%s?key=%s", endpointURL, apiKey)
+	reqURL := fmt.Sprintf("%s?key=%s", endpointURL, cfg.APIKey)
 	req, err := http.NewRequestWithContext(ctx, "POST", reqURL, bytes.NewBuffer(jsonData))
 	if err != nil {
 		return CompletionResponse{}, fmt.Errorf("failed to create http request: %w", err)


### PR DESCRIPTION
Refactored `GenerateGeminiCompletion` in `internal/llm/gemini.go` to use a `GeminiConfig` struct instead of multiple individual parameters. This change simplifies the function signature and improves the overall code health and maintainability of the Gemini API interaction logic. The corresponding call site in `internal/api/handlers_chat.go` was also updated to use the new struct.

---
*PR created automatically by Jules for task [7318189334344159825](https://jules.google.com/task/7318189334344159825) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal API structure to enhance code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->