### PR TITLE
Add guardrails util and apply input/output clamping; add polyglot benchmark fixtures and KPI benchmark; add modernization plan

### DIFF
--- a/benchmark/fixtures/polyglot/README.md
+++ b/benchmark/fixtures/polyglot/README.md
@@ -1,0 +1,4 @@
+# Polyglot Fixture
+
+This fixture is used for deterministic retrieval benchmarks.
+It intentionally contains small Go, TypeScript, Python, and Markdown content.

--- a/benchmark/fixtures/polyglot/kpi_thresholds.json
+++ b/benchmark/fixtures/polyglot/kpi_thresholds.json
@@ -1,0 +1,5 @@
+{
+  "min_recall": 0.66,
+  "min_mrr": 0.50,
+  "min_ndcg": 0.58
+}

--- a/benchmark/fixtures/polyglot/main.go
+++ b/benchmark/fixtures/polyglot/main.go
@@ -1,0 +1,11 @@
+package main
+
+import "fmt"
+
+func Add(a, b int) int {
+	return a + b
+}
+
+func main() {
+	fmt.Println(Add(2, 3))
+}

--- a/benchmark/fixtures/polyglot/service.ts
+++ b/benchmark/fixtures/polyglot/service.ts
@@ -1,0 +1,8 @@
+export type User = {
+  id: string;
+  name: string;
+};
+
+export function findUser(users: User[], id: string): User | undefined {
+  return users.find((u) => u.id === id);
+}

--- a/benchmark/fixtures/polyglot/worker.py
+++ b/benchmark/fixtures/polyglot/worker.py
@@ -1,0 +1,6 @@
+def normalize(text: str) -> str:
+    return text.strip().lower()
+
+
+def run(items: list[str]) -> list[str]:
+    return [normalize(i) for i in items]

--- a/benchmark/retrieval_bench_test.go
+++ b/benchmark/retrieval_bench_test.go
@@ -2,6 +2,7 @@ package benchmark
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"hash/fnv"
 	"math"
@@ -21,6 +22,7 @@ type deterministicEmbedder struct {
 	dim int
 }
 
+// Embed returns a deterministic embedding for stable benchmark assertions.
 func (m *deterministicEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
 	if m.dim <= 0 {
 		m.dim = 384
@@ -37,6 +39,7 @@ func (m *deterministicEmbedder) Embed(ctx context.Context, text string) ([]float
 	return emb, nil
 }
 
+// EmbedBatch embeds a list of inputs using the same deterministic mapping as Embed.
 func (m *deterministicEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
 	out := make([][]float32, len(texts))
 	for i, txt := range texts {
@@ -49,6 +52,14 @@ func (m *deterministicEmbedder) EmbedBatch(ctx context.Context, texts []string) 
 	return out, nil
 }
 
+// retrievalKPIThresholds captures minimum acceptable quality values for the fixture benchmark.
+type retrievalKPIThresholds struct {
+	MinRecall float64 `json:"min_recall"`
+	MinMRR    float64 `json:"min_mrr"`
+	MinNDCG   float64 `json:"min_ndcg"`
+}
+
+// countLines returns the number of lines in a string.
 func countLines(s string) int {
 	if s == "" {
 		return 0
@@ -56,12 +67,31 @@ func countLines(s string) int {
 	return strings.Count(s, "\n") + 1
 }
 
+// loadKPIThresholds reads deterministic KPI thresholds for regression detection.
+func loadKPIThresholds(path string) (retrievalKPIThresholds, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return retrievalKPIThresholds{}, err
+	}
+	var thresholds retrievalKPIThresholds
+	if err := json.Unmarshal(b, &thresholds); err != nil {
+		return retrievalKPIThresholds{}, err
+	}
+	return thresholds, nil
+}
+
+// TestRetrievalKPIsOnPolyglotFixture validates benchmark quality KPIs against fixture-backed minimums.
 func TestRetrievalKPIsOnPolyglotFixture(t *testing.T) {
 	ctx := context.Background()
 	fixtureRoot := filepath.Join("fixtures", "polyglot")
+	thresholdPath := filepath.Join(fixtureRoot, "kpi_thresholds.json")
 
 	if _, err := os.Stat(fixtureRoot); err != nil {
 		t.Fatalf("fixture not found at %s: %v", fixtureRoot, err)
+	}
+	thresholds, err := loadKPIThresholds(thresholdPath)
+	if err != nil {
+		t.Fatalf("failed to load KPI thresholds from %s: %v", thresholdPath, err)
 	}
 
 	tempDBDir := t.TempDir()
@@ -173,17 +203,18 @@ func TestRetrievalKPIsOnPolyglotFixture(t *testing.T) {
 	t.Logf("KPI index_time_per_KLOC=%.3fs", indexPerKLOC)
 	t.Logf("KPI p50_latency=%s p95_latency=%s", p50Latency, p95Latency)
 
-	if recallAtK < 0 || recallAtK > 1 {
-		t.Fatalf("invalid recall@k: %f", recallAtK)
+	if recallAtK < thresholds.MinRecall {
+		t.Fatalf("recall@%d regression: got %.3f, want >= %.3f", k, recallAtK, thresholds.MinRecall)
 	}
-	if mrr < 0 || mrr > 1 {
-		t.Fatalf("invalid mrr: %f", mrr)
+	if mrr < thresholds.MinMRR {
+		t.Fatalf("mrr regression: got %.3f, want >= %.3f", mrr, thresholds.MinMRR)
 	}
-	if avgNDCG < 0 || avgNDCG > 1 {
-		t.Fatalf("invalid ndcg: %f", avgNDCG)
+	if avgNDCG < thresholds.MinNDCG {
+		t.Fatalf("ndcg@%d regression: got %.3f, want >= %.3f", k, avgNDCG, thresholds.MinNDCG)
 	}
 }
 
+// collectFixtureFiles returns all files under the fixture root.
 func collectFixtureFiles(root string) ([]string, error) {
 	files := []string{}
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
@@ -199,6 +230,7 @@ func collectFixtureFiles(root string) ([]string, error) {
 	return files, err
 }
 
+// extractPaths pulls path metadata from records in ranked order.
 func extractPaths(records []db.Record) []string {
 	paths := make([]string, 0, len(records))
 	for _, r := range records {
@@ -207,6 +239,7 @@ func extractPaths(records []db.Record) []string {
 	return paths
 }
 
+// containsPath checks whether expected appears in the ranked path list.
 func containsPath(paths []string, expected string) bool {
 	for _, p := range paths {
 		if strings.Contains(p, expected) {
@@ -216,6 +249,7 @@ func containsPath(paths []string, expected string) bool {
 	return false
 }
 
+// reciprocalRank computes reciprocal rank for a single relevant expected path.
 func reciprocalRank(paths []string, expected string) float64 {
 	for i, p := range paths {
 		if strings.Contains(p, expected) {
@@ -225,6 +259,7 @@ func reciprocalRank(paths []string, expected string) float64 {
 	return 0
 }
 
+// ndcgAtK computes a binary-relevance NDCG at k for expected path membership.
 func ndcgAtK(paths []string, expected string, k int) float64 {
 	if k <= 0 {
 		return 0
@@ -245,6 +280,7 @@ func ndcgAtK(paths []string, expected string, k int) float64 {
 	return dcg / idcg
 }
 
+// mean returns the arithmetic average of values.
 func mean(values []float64) float64 {
 	if len(values) == 0 {
 		return 0
@@ -256,6 +292,7 @@ func mean(values []float64) float64 {
 	return total / float64(len(values))
 }
 
+// percentileDuration returns the nearest-rank percentile for a duration slice.
 func percentileDuration(values []time.Duration, p float64) time.Duration {
 	if len(values) == 0 {
 		return 0
@@ -274,6 +311,7 @@ func percentileDuration(values []time.Duration, p float64) time.Duration {
 	return copied[idx]
 }
 
+// min returns the smaller integer.
 func min(a, b int) int {
 	if a < b {
 		return a
@@ -281,6 +319,7 @@ func min(a, b int) int {
 	return b
 }
 
+// max returns the larger integer.
 func max(a, b int) int {
 	if a > b {
 		return a

--- a/benchmark/retrieval_bench_test.go
+++ b/benchmark/retrieval_bench_test.go
@@ -1,0 +1,289 @@
+package benchmark
+
+import (
+	"context"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nilesh32236/vector-mcp-go/internal/config"
+	"github.com/nilesh32236/vector-mcp-go/internal/db"
+	"github.com/nilesh32236/vector-mcp-go/internal/indexer"
+)
+
+type deterministicEmbedder struct {
+	dim int
+}
+
+func (m *deterministicEmbedder) Embed(ctx context.Context, text string) ([]float32, error) {
+	if m.dim <= 0 {
+		m.dim = 384
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(text))
+	seed := h.Sum32()
+
+	emb := make([]float32, m.dim)
+	for i := 0; i < m.dim; i++ {
+		v := float32((seed+uint32(i*31))%1000) / 1000.0
+		emb[i] = v
+	}
+	return emb, nil
+}
+
+func (m *deterministicEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i, txt := range texts {
+		emb, err := m.Embed(ctx, txt)
+		if err != nil {
+			return nil, err
+		}
+		out[i] = emb
+	}
+	return out, nil
+}
+
+func countLines(s string) int {
+	if s == "" {
+		return 0
+	}
+	return strings.Count(s, "\n") + 1
+}
+
+func TestRetrievalKPIsOnPolyglotFixture(t *testing.T) {
+	ctx := context.Background()
+	fixtureRoot := filepath.Join("fixtures", "polyglot")
+
+	if _, err := os.Stat(fixtureRoot); err != nil {
+		t.Fatalf("fixture not found at %s: %v", fixtureRoot, err)
+	}
+
+	tempDBDir := t.TempDir()
+	store, err := db.Connect(ctx, tempDBDir, "bench_collection", 384)
+	if err != nil {
+		t.Fatalf("db connect failed: %v", err)
+	}
+
+	emb := &deterministicEmbedder{dim: 384}
+	projectID := filepath.Clean(fixtureRoot)
+
+	files, err := collectFixtureFiles(fixtureRoot)
+	if err != nil {
+		t.Fatalf("collect files failed: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no fixture files found")
+	}
+
+	totalLOC := 0
+	indexStart := time.Now()
+	for _, f := range files {
+		b, readErr := os.ReadFile(f)
+		if readErr != nil {
+			t.Fatalf("read file failed (%s): %v", f, readErr)
+		}
+		content := string(b)
+		totalLOC += countLines(content)
+		chunks := indexer.CreateChunks(content, f)
+		if len(chunks) == 0 {
+			continue
+		}
+
+		relPath := config.GetRelativePath(f, fixtureRoot)
+		recs := make([]db.Record, 0, len(chunks))
+		for i, c := range chunks {
+			vec, embErr := emb.Embed(ctx, c.Content)
+			if embErr != nil {
+				t.Fatalf("embed failed: %v", embErr)
+			}
+			recs = append(recs, db.Record{
+				ID:        fmt.Sprintf("%s-%d", relPath, i),
+				Content:   c.Content,
+				Embedding: vec,
+				Metadata: map[string]string{
+					"path":       relPath,
+					"project_id": projectID,
+					"category":   "code",
+				},
+			})
+		}
+		if insErr := store.Insert(ctx, recs); insErr != nil {
+			t.Fatalf("insert failed: %v", insErr)
+		}
+	}
+	indexDur := time.Since(indexStart)
+
+	if totalLOC <= 0 {
+		t.Fatal("fixture LOC must be > 0")
+	}
+
+	type queryCase struct {
+		query        string
+		expectedPath string
+	}
+	queries := []queryCase{
+		{query: "add two integers", expectedPath: "main.go"},
+		{query: "find a user by id", expectedPath: "service.ts"},
+		{query: "normalize string lowercase", expectedPath: "worker.py"},
+	}
+
+	k := 3
+	hits := 0
+	reciprocalRanks := make([]float64, 0, len(queries))
+	ndcgs := make([]float64, 0, len(queries))
+	latencies := make([]time.Duration, 0, len(queries))
+
+	for _, q := range queries {
+		qv, embErr := emb.Embed(ctx, q.query)
+		if embErr != nil {
+			t.Fatalf("query embed failed: %v", embErr)
+		}
+
+		start := time.Now()
+		res, searchErr := store.HybridSearch(ctx, q.query, qv, k, []string{projectID}, "")
+		latencies = append(latencies, time.Since(start))
+		if searchErr != nil {
+			t.Fatalf("search failed for query %q: %v", q.query, searchErr)
+		}
+
+		rankedPaths := extractPaths(res)
+		if containsPath(rankedPaths[:min(k, len(rankedPaths))], q.expectedPath) {
+			hits++
+		}
+		reciprocalRanks = append(reciprocalRanks, reciprocalRank(rankedPaths, q.expectedPath))
+		ndcgs = append(ndcgs, ndcgAtK(rankedPaths, q.expectedPath, k))
+	}
+
+	recallAtK := float64(hits) / float64(len(queries))
+	mrr := mean(reciprocalRanks)
+	avgNDCG := mean(ndcgs)
+	p50Latency := percentileDuration(latencies, 50)
+	p95Latency := percentileDuration(latencies, 95)
+	indexPerKLOC := indexDur.Seconds() / (float64(totalLOC) / 1000.0)
+
+	t.Logf("KPI recall@%d=%.3f", k, recallAtK)
+	t.Logf("KPI MRR=%.3f", mrr)
+	t.Logf("KPI NDCG@%d=%.3f", k, avgNDCG)
+	t.Logf("KPI index_time_per_KLOC=%.3fs", indexPerKLOC)
+	t.Logf("KPI p50_latency=%s p95_latency=%s", p50Latency, p95Latency)
+
+	if recallAtK < 0 || recallAtK > 1 {
+		t.Fatalf("invalid recall@k: %f", recallAtK)
+	}
+	if mrr < 0 || mrr > 1 {
+		t.Fatalf("invalid mrr: %f", mrr)
+	}
+	if avgNDCG < 0 || avgNDCG > 1 {
+		t.Fatalf("invalid ndcg: %f", avgNDCG)
+	}
+}
+
+func collectFixtureFiles(root string) ([]string, error) {
+	files := []string{}
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	return files, err
+}
+
+func extractPaths(records []db.Record) []string {
+	paths := make([]string, 0, len(records))
+	for _, r := range records {
+		paths = append(paths, r.Metadata["path"])
+	}
+	return paths
+}
+
+func containsPath(paths []string, expected string) bool {
+	for _, p := range paths {
+		if strings.Contains(p, expected) {
+			return true
+		}
+	}
+	return false
+}
+
+func reciprocalRank(paths []string, expected string) float64 {
+	for i, p := range paths {
+		if strings.Contains(p, expected) {
+			return 1.0 / float64(i+1)
+		}
+	}
+	return 0
+}
+
+func ndcgAtK(paths []string, expected string, k int) float64 {
+	if k <= 0 {
+		return 0
+	}
+	limit := min(k, len(paths))
+	dcg := 0.0
+	for i := 0; i < limit; i++ {
+		rel := 0.0
+		if strings.Contains(paths[i], expected) {
+			rel = 1.0
+		}
+		dcg += rel / math.Log2(float64(i+2))
+	}
+	idcg := 1.0
+	if idcg == 0 {
+		return 0
+	}
+	return dcg / idcg
+}
+
+func mean(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	total := 0.0
+	for _, v := range values {
+		total += v
+	}
+	return total / float64(len(values))
+}
+
+func percentileDuration(values []time.Duration, p float64) time.Duration {
+	if len(values) == 0 {
+		return 0
+	}
+	if p < 0 {
+		p = 0
+	}
+	if p > 100 {
+		p = 100
+	}
+	copied := append([]time.Duration(nil), values...)
+	sort.Slice(copied, func(i, j int) bool { return copied[i] < copied[j] })
+
+	idx := int(math.Ceil((p/100.0)*float64(len(copied)))) - 1
+	idx = min(max(idx, 0), len(copied)-1)
+	return copied[idx]
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/benchmark/retrieval_bench_test.go
+++ b/benchmark/retrieval_bench_test.go
@@ -77,6 +77,15 @@ func loadKPIThresholds(path string) (retrievalKPIThresholds, error) {
 	if err := json.Unmarshal(b, &thresholds); err != nil {
 		return retrievalKPIThresholds{}, err
 	}
+	if !isPositiveFinite(thresholds.MinRecall) {
+		return retrievalKPIThresholds{}, fmt.Errorf("invalid min_recall: %v (must be finite and > 0)", thresholds.MinRecall)
+	}
+	if !isPositiveFinite(thresholds.MinMRR) {
+		return retrievalKPIThresholds{}, fmt.Errorf("invalid min_mrr: %v (must be finite and > 0)", thresholds.MinMRR)
+	}
+	if !isPositiveFinite(thresholds.MinNDCG) {
+		return retrievalKPIThresholds{}, fmt.Errorf("invalid min_ndcg: %v (must be finite and > 0)", thresholds.MinNDCG)
+	}
 	return thresholds, nil
 }
 
@@ -126,23 +135,22 @@ func TestRetrievalKPIsOnPolyglotFixture(t *testing.T) {
 		}
 
 		relPath := config.GetRelativePath(f, fixtureRoot)
-		recs := make([]db.Record, 0, len(chunks))
-		for i, c := range chunks {
-			vec, embErr := emb.Embed(ctx, c.Content)
-			if embErr != nil {
-				t.Fatalf("embed failed: %v", embErr)
-			}
-			recs = append(recs, db.Record{
-				ID:        fmt.Sprintf("%s-%d", relPath, i),
-				Content:   c.Content,
-				Embedding: vec,
-				Metadata: map[string]string{
-					"path":       relPath,
-					"project_id": projectID,
-					"category":   "code",
-				},
-			})
+		fileContent := content
+		fileEmbedding, embErr := emb.Embed(ctx, fileContent)
+		if embErr != nil {
+			t.Fatalf("embed failed for file %s: %v", relPath, embErr)
 		}
+
+		recs := []db.Record{{
+			ID:        fmt.Sprintf("%s-0", relPath),
+			Content:   fileContent,
+			Embedding: fileEmbedding,
+			Metadata: map[string]string{
+				"path":       relPath,
+				"project_id": projectID,
+				"category":   "code",
+			},
+		}}
 		if insErr := store.Insert(ctx, recs); insErr != nil {
 			t.Fatalf("insert failed: %v", insErr)
 		}
@@ -182,8 +190,9 @@ func TestRetrievalKPIsOnPolyglotFixture(t *testing.T) {
 			t.Fatalf("search failed for query %q: %v", q.query, searchErr)
 		}
 
-		rankedPaths := extractPaths(res)
-		if containsPath(rankedPaths[:min(k, len(rankedPaths))], q.expectedPath) {
+		rankedPaths := dedupePaths(extractPaths(res))
+		topKPaths := rankedPaths[:min(k, len(rankedPaths))]
+		if containsPath(topKPaths, q.expectedPath) {
 			hits++
 		}
 		reciprocalRanks = append(reciprocalRanks, reciprocalRank(rankedPaths, q.expectedPath))
@@ -214,6 +223,11 @@ func TestRetrievalKPIsOnPolyglotFixture(t *testing.T) {
 	}
 }
 
+// isPositiveFinite reports whether v is finite and strictly positive.
+func isPositiveFinite(v float64) bool {
+	return v > 0 && !math.IsNaN(v) && !math.IsInf(v, 0)
+}
+
 // collectFixtureFiles returns all files under the fixture root.
 func collectFixtureFiles(root string) ([]string, error) {
 	files := []string{}
@@ -239,10 +253,24 @@ func extractPaths(records []db.Record) []string {
 	return paths
 }
 
+// dedupePaths removes duplicate paths while preserving ranked order.
+func dedupePaths(paths []string) []string {
+	seen := make(map[string]struct{}, len(paths))
+	deduped := make([]string, 0, len(paths))
+	for _, p := range paths {
+		if _, exists := seen[p]; exists {
+			continue
+		}
+		seen[p] = struct{}{}
+		deduped = append(deduped, p)
+	}
+	return deduped
+}
+
 // containsPath checks whether expected appears in the ranked path list.
 func containsPath(paths []string, expected string) bool {
 	for _, p := range paths {
-		if strings.Contains(p, expected) {
+		if p == expected {
 			return true
 		}
 	}
@@ -252,7 +280,7 @@ func containsPath(paths []string, expected string) bool {
 // reciprocalRank computes reciprocal rank for a single relevant expected path.
 func reciprocalRank(paths []string, expected string) float64 {
 	for i, p := range paths {
-		if strings.Contains(p, expected) {
+		if p == expected {
 			return 1.0 / float64(i+1)
 		}
 	}
@@ -268,7 +296,7 @@ func ndcgAtK(paths []string, expected string, k int) float64 {
 	dcg := 0.0
 	for i := 0; i < limit; i++ {
 		rel := 0.0
-		if strings.Contains(paths[i], expected) {
+		if paths[i] == expected {
 			rel = 1.0
 		}
 		dcg += rel / math.Log2(float64(i+2))

--- a/docs/technology-modernization-plan.md
+++ b/docs/technology-modernization-plan.md
@@ -1,0 +1,140 @@
+# Technology Verification and Modernization Plan
+
+## 1) Current-State Verification (as of March 31, 2026)
+
+This repository is already using a modern and practical baseline for a deterministic MCP server:
+
+- **Deterministic architecture** (no generative model dependency in server runtime).
+- **Fat-tool MCP design** with a narrow tool surface (`search_workspace`, `lsp_query`, `analyze_code`, `workspace_manager`, `modify_workspace`).
+- **Local embedding stack** using ONNX runtime (good for privacy, latency, and predictable cost).
+- **Go monolith with modular internals** (indexing, embedding, analysis, mutation safety, daemon/watcher).
+- **Automated test coverage present** across core packages.
+
+Conclusion: The project is **technically viable** and is a good fit for teams that want local-first, deterministic context retrieval and safe code operations.
+
+---
+
+## 2) Can we implement “latest technology” here?
+
+**Yes — with constraints.**
+
+You can adopt modern capabilities **without violating determinism** by focusing on:
+
+1. **Retrieval quality upgrades** (better reranking, chunking quality, metadata scoring, hybrid ranking).
+2. **Performance upgrades** (incremental indexing, adaptive caching, streaming partial results).
+3. **Reliability and safety upgrades** (strong parameter clamping, UTF-8 rune-safe truncation everywhere, fuzz/property tests).
+4. **Operations upgrades** (metrics, traces, benchmark gates, release automation).
+
+You should avoid adding server-side generative behavior; this repository is designed so the client LLM handles reasoning.
+
+---
+
+## 3) Advantages vs Disadvantages
+
+## Advantages
+
+- **Deterministic and auditable outputs**: easier debugging and safer enterprise adoption.
+- **Data privacy**: local embeddings and local vector storage reduce third-party exposure.
+- **Lower variable cost**: less dependency on paid external inference APIs.
+- **Strong MCP usability**: fat-tool pattern reduces tool confusion for agents.
+- **Good extensibility path**: actions can be added into existing unified tools.
+
+## Disadvantages / Trade-offs
+
+- **Quality ceiling from non-generative server design**: no server-side synthesis means quality depends on retrieval and client prompting.
+- **ONNX/CGO operational complexity**: native runtime handling can complicate distribution and CI.
+- **Index freshness pressure**: large repos need careful incremental indexing and backpressure control.
+- **Potential latency variance** on big workspaces if ranking/index operations are not tuned.
+- **Higher engineering burden** for deterministic heuristics that approximate what gen models might summarize quickly.
+
+---
+
+## 4) Fit Assessment
+
+This project is a **strong fit** if your goals are:
+
+- deterministic MCP tool execution,
+- local/private semantic search,
+- safe workspace mutation workflows,
+- and stable enterprise behavior over “creative” server outputs.
+
+It is a **weaker fit** if your primary goal is autonomous generative coding inside the server itself.
+
+---
+
+## 5) Recommended Implementation Plan
+
+## Phase 0 — Baseline & Guardrails (1 week)
+
+- Freeze a benchmark dataset of representative repositories.
+- Define quality KPIs:
+  - retrieval recall@k,
+  - MRR/NDCG for top results,
+  - index time per KLOC,
+  - p50/p95 tool latency.
+- Enforce global guardrails:
+  - numeric parameter clamp helpers (`topK`, `limit`, etc.),
+  - rune-safe truncation utility for all output caps,
+  - timeout/cancellation defaults for expensive paths.
+
+**Exit criteria:** reproducible baseline report committed.
+
+## Phase 1 — Retrieval Quality Upgrade (2–3 weeks)
+
+- Improve chunking policy by language/file type.
+- Add richer ranking features (symbol hits, proximity, path relevance, recency weighting).
+- Strengthen rerank pipeline with deterministic score blending.
+- Expand test fixtures for polyglot repositories.
+
+**Integrate through existing fat tools only** (primarily `search_workspace` and `analyze_code` actions).
+
+**Exit criteria:** measurable recall/MRR uplift without p95 regression >15%.
+
+## Phase 2 — Performance & Scale (2 weeks)
+
+- Introduce more aggressive incremental indexing and dirty-file scheduling.
+- Add memory-aware backpressure tuning in worker/index pipeline.
+- Optional parallel embedding batch optimization with bounded concurrency.
+
+**Exit criteria:** index throughput and p95 latency improvements on large repos.
+
+## Phase 3 — Reliability & Safety Hardening (1–2 weeks)
+
+- Add fuzz tests for request payloads and edge-case encodings.
+- Add integration tests for daemon master/slave failover behavior.
+- Add panic-proofing around all slices/limits from user input.
+
+**Exit criteria:** zero known crashers in fuzz and integration suites.
+
+## Phase 4 — Operational Excellence (1 week)
+
+- Add OpenTelemetry metrics/tracing hooks (deterministic telemetry only).
+- Publish dashboard templates for latency/index health.
+- Add release pipeline checks (benchmarks + tests + lint gates).
+
+**Exit criteria:** release checklist fully automated.
+
+---
+
+## 6) Decision Matrix (Go / No-Go)
+
+Proceed now if all are true:
+
+- You want deterministic, local-first architecture.
+- You can invest in retrieval/index engineering rather than server-side generation.
+- You need predictable cost and stronger privacy posture.
+
+Defer or redesign if:
+
+- You need server to generate long-form reasoning itself,
+- or you cannot support native runtime dependencies in your deployment environment.
+
+---
+
+## 7) Practical Next Steps (Immediate)
+
+1. Create a `benchmark/` fixture set and KPI script.
+2. Add shared helpers for parameter clamping + rune-safe truncation.
+3. Add `search_workspace` ranking action improvements behind a config flag.
+4. Run A/B benchmark and promote only if KPI gates pass.
+

--- a/docs/technology-modernization-plan.md
+++ b/docs/technology-modernization-plan.md
@@ -133,8 +133,12 @@ Defer or redesign if:
 
 ## 7) Practical Next Steps (Immediate)
 
-1. Create a `benchmark/` fixture set and KPI script.
-2. Add shared helpers for parameter clamping + rune-safe truncation.
-3. Add `search_workspace` ranking action improvements behind a config flag.
-4. Run A/B benchmark and promote only if KPI gates pass.
+Completed baseline work in this branch:
 
+1. ✅ Added a deterministic `benchmark/` polyglot fixture set and KPI benchmark coverage.
+2. ✅ Added shared helpers and call-site adoption for parameter clamping + rune-safe truncation.
+
+Remaining immediate actions:
+
+1. Add `search_workspace` ranking action improvements behind a config flag.
+2. Run A/B benchmark and promote only if KPI gates pass.

--- a/internal/api/handlers_tools.go
+++ b/internal/api/handlers_tools.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/nilesh32236/vector-mcp-go/internal/db"
+	"github.com/nilesh32236/vector-mcp-go/internal/util"
 )
 
 // SearchRequest defines the criteria for a semantic and lexical search.
@@ -32,9 +33,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.TopK <= 0 {
-		req.TopK = 5 // default
-	}
+	req.TopK = util.ClampInt(req.TopK, 1, 100)
 
 	emb, err := s.embedder.Embed(r.Context(), req.Query)
 	if err != nil {
@@ -60,9 +59,13 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	var resp []SearchResponse
 	for _, rec := range records {
+		text := util.TruncateRuneSafe(rec.Content, 4000)
+		if text != rec.Content {
+			text += "\n... [Truncated for length]"
+		}
 		resp = append(resp, SearchResponse{
 			ID:         rec.ID,
-			Text:       rec.Content,
+			Text:       text,
 			Similarity: rec.Similarity,
 			Metadata:   rec.Metadata,
 		})

--- a/internal/api/handlers_tools.go
+++ b/internal/api/handlers_tools.go
@@ -33,6 +33,10 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Preserve historical default behavior when top_k is omitted in JSON (zero value).
+	if req.TopK == 0 {
+		req.TopK = 5
+	}
 	req.TopK = util.ClampInt(req.TopK, 1, 100)
 
 	emb, err := s.embedder.Embed(r.Context(), req.Query)

--- a/internal/mcp/handlers_analysis.go
+++ b/internal/mcp/handlers_analysis.go
@@ -24,7 +24,11 @@ func (s *Server) handleGetRelatedContext(ctx context.Context, request mcp.CallTo
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	filePath := request.GetString("filePath", "")
-	maxTokens := util.ClampInt(int(request.GetFloat("max_tokens", float64(indexer.MaxContextTokens))), 1, indexer.MaxContextTokens)
+	maxTokensFloat := request.GetFloat("max_tokens", float64(indexer.MaxContextTokens))
+	if maxTokensFloat <= 0 {
+		maxTokensFloat = float64(indexer.MaxContextTokens)
+	}
+	maxTokens := util.ClampInt(int(maxTokensFloat), 1, indexer.MaxContextTokens)
 
 	store, err := s.getStore(ctx)
 	if err != nil {
@@ -1146,18 +1150,19 @@ func (s *Server) handleDistillKnowledge(ctx context.Context, request mcp.CallToo
 	}
 
 	contentStr := relevantContent.String()
-	truncated := util.TruncateRuneSafe(contentStr, 10000)
-	if truncated != contentStr {
-		contentStr = truncated + "\n... [Truncated for length]"
+	truncatedContent := util.TruncateRuneSafe(contentStr, 10000)
+	toolText := truncatedContent
+	if truncatedContent != contentStr {
+		toolText = truncatedContent + "\n... [Truncated for length]"
 	}
 
-	storeErr := s.storeContext(ctx, contentStr, s.cfg.ProjectRoot)
+	storeErr := s.storeContext(ctx, truncatedContent, s.cfg.ProjectRoot)
 	if storeErr != nil {
 		s.logger.Error("Failed to store distilled context", "error", storeErr)
-		return mcp.NewToolResultText(fmt.Sprintf("### 🧠 Distilled Knowledge (Storage Failed)\n\n%s\n\n**Warning**: Failed to index this KI automatically.", contentStr)), nil
+		return mcp.NewToolResultText(fmt.Sprintf("### 🧠 Distilled Knowledge (Storage Failed)\n\n%s\n\n**Warning**: Failed to index this KI automatically.", toolText)), nil
 	}
 
-	return mcp.NewToolResultText(fmt.Sprintf("### ✅ Knowledge Distilled & Indexed\n\n%s", contentStr)), nil
+	return mcp.NewToolResultText(fmt.Sprintf("### ✅ Knowledge Distilled & Indexed\n\n%s", toolText)), nil
 }
 
 // storeContext is a helper to save KIs to the database

--- a/internal/mcp/handlers_analysis.go
+++ b/internal/mcp/handlers_analysis.go
@@ -24,10 +24,7 @@ func (s *Server) handleGetRelatedContext(ctx context.Context, request mcp.CallTo
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	filePath := request.GetString("filePath", "")
-	maxTokens := int(request.GetFloat("max_tokens", float64(indexer.MaxContextTokens)))
-	if maxTokens <= 0 {
-		maxTokens = indexer.MaxContextTokens
-	}
+	maxTokens := util.ClampInt(int(request.GetFloat("max_tokens", float64(indexer.MaxContextTokens))), 1, indexer.MaxContextTokens)
 
 	store, err := s.getStore(ctx)
 	if err != nil {
@@ -1024,7 +1021,7 @@ func (s *Server) handleGetSummarizedContext(ctx context.Context, request mcp.Cal
 	if query == "" {
 		return mcp.NewToolResultError("query is required"), nil
 	}
-	topK := int(request.GetFloat("topK", 5))
+	topK := util.ClampInt(int(request.GetFloat("topK", 5)), 1, 100)
 
 	store, err := s.getStore(ctx)
 	if err != nil {
@@ -1149,9 +1146,9 @@ func (s *Server) handleDistillKnowledge(ctx context.Context, request mcp.CallToo
 	}
 
 	contentStr := relevantContent.String()
-	r := []rune(contentStr)
-	if len(r) > 10000 {
-		contentStr = string(r[:10000]) + "\n... [Truncated for length]"
+	truncated := util.TruncateRuneSafe(contentStr, 10000)
+	if truncated != contentStr {
+		contentStr = truncated + "\n... [Truncated for length]"
 	}
 
 	storeErr := s.storeContext(ctx, contentStr, s.cfg.ProjectRoot)

--- a/internal/mcp/handlers_analysis_extended.go
+++ b/internal/mcp/handlers_analysis_extended.go
@@ -6,14 +6,15 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/nilesh32236/vector-mcp-go/internal/util"
 )
 
 // handleGetImpactAnalysis uses the LSP to identify the "blast radius" of a change to a symbol.
 // It finds all references across the project and summarizes the potential impact.
 func (s *Server) handleGetImpactAnalysis(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path := request.GetString("path", "")
-	line := int(request.GetFloat("line", 0))
-	character := int(request.GetFloat("character", 0))
+	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
+	character := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
 
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil

--- a/internal/mcp/handlers_lsp.go
+++ b/internal/mcp/handlers_lsp.go
@@ -9,11 +9,15 @@ import (
 	"github.com/nilesh32236/vector-mcp-go/internal/util"
 )
 
-// handleGetPreciseDefinition uses the LSP to find exact symbol definitions.
-func (s *Server) handleGetPreciseDefinition(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	path := request.GetString("path", "")
+// parseAndClampLSPPosition reads and clamps LSP line/character request arguments once.
+func parseAndClampLSPPosition(request mcp.CallToolRequest) (int, int) {
 	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
-	char := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
+	character := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
+	return line, character
+}
+
+// handleGetPreciseDefinition uses the LSP to find exact symbol definitions.
+func (s *Server) handleGetPreciseDefinition(ctx context.Context, path string, line, character int) (*mcp.CallToolResult, error) {
 
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil
@@ -30,7 +34,7 @@ func (s *Server) handleGetPreciseDefinition(ctx context.Context, request mcp.Cal
 		},
 		"position": map[string]interface{}{
 			"line":      line,
-			"character": char,
+			"character": character,
 		},
 	}
 
@@ -49,11 +53,7 @@ func (s *Server) handleGetPreciseDefinition(ctx context.Context, request mcp.Cal
 }
 
 // handleFindReferencesPrecise uses the LSP to find all usages of a symbol.
-func (s *Server) handleFindReferencesPrecise(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	path := request.GetString("path", "")
-	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
-	char := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
-
+func (s *Server) handleFindReferencesPrecise(ctx context.Context, path string, line, character int) (*mcp.CallToolResult, error) {
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil
 	}
@@ -69,7 +69,7 @@ func (s *Server) handleFindReferencesPrecise(ctx context.Context, request mcp.Ca
 		},
 		"position": map[string]interface{}{
 			"line":      line,
-			"character": char,
+			"character": character,
 		},
 		"context": map[string]interface{}{
 			"includeDeclaration": true,
@@ -95,11 +95,7 @@ func (s *Server) handleFindReferencesPrecise(ctx context.Context, request mcp.Ca
 }
 
 // handleGetTypeHierarchy uses the LSP to map out type structures.
-func (s *Server) handleGetTypeHierarchy(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	path := request.GetString("path", "")
-	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
-	char := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
-
+func (s *Server) handleGetTypeHierarchy(ctx context.Context, path string, line, character int) (*mcp.CallToolResult, error) {
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil
 	}
@@ -115,7 +111,7 @@ func (s *Server) handleGetTypeHierarchy(ctx context.Context, request mcp.CallToo
 		},
 		"position": map[string]interface{}{
 			"line":      line,
-			"character": char,
+			"character": character,
 		},
 	}
 
@@ -133,40 +129,15 @@ func (s *Server) handleGetTypeHierarchy(ctx context.Context, request mcp.CallToo
 func (s *Server) handleLspQuery(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	action := request.GetString("action", "")
 	path := request.GetString("path", "")
-	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
-	character := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
+	line, character := parseAndClampLSPPosition(request)
 
 	switch action {
 	case "definition":
-		return s.handleGetPreciseDefinition(ctx, mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Arguments: map[string]interface{}{
-					"path":      path,
-					"line":      float64(line),
-					"character": float64(character),
-				},
-			},
-		})
+		return s.handleGetPreciseDefinition(ctx, path, line, character)
 	case "references":
-		return s.handleFindReferencesPrecise(ctx, mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Arguments: map[string]interface{}{
-					"path":      path,
-					"line":      float64(line),
-					"character": float64(character),
-				},
-			},
-		})
+		return s.handleFindReferencesPrecise(ctx, path, line, character)
 	case "type_hierarchy":
-		return s.handleGetTypeHierarchy(ctx, mcp.CallToolRequest{
-			Params: mcp.CallToolParams{
-				Arguments: map[string]interface{}{
-					"path":      path,
-					"line":      float64(line),
-					"character": float64(character),
-				},
-			},
-		})
+		return s.handleGetTypeHierarchy(ctx, path, line, character)
 	case "impact_analysis":
 		return s.handleGetImpactAnalysis(ctx, mcp.CallToolRequest{
 			Params: mcp.CallToolParams{

--- a/internal/mcp/handlers_lsp.go
+++ b/internal/mcp/handlers_lsp.go
@@ -6,13 +6,14 @@ import (
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/nilesh32236/vector-mcp-go/internal/util"
 )
 
 // handleGetPreciseDefinition uses the LSP to find exact symbol definitions.
 func (s *Server) handleGetPreciseDefinition(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path := request.GetString("path", "")
-	line := request.GetFloat("line", 0)
-	char := request.GetFloat("character", 0)
+	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
+	char := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
 
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil
@@ -28,8 +29,8 @@ func (s *Server) handleGetPreciseDefinition(ctx context.Context, request mcp.Cal
 			"uri": fmt.Sprintf("file://%s", path),
 		},
 		"position": map[string]interface{}{
-			"line":      int(line),
-			"character": int(char),
+			"line":      line,
+			"character": char,
 		},
 	}
 
@@ -50,8 +51,8 @@ func (s *Server) handleGetPreciseDefinition(ctx context.Context, request mcp.Cal
 // handleFindReferencesPrecise uses the LSP to find all usages of a symbol.
 func (s *Server) handleFindReferencesPrecise(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path := request.GetString("path", "")
-	line := request.GetFloat("line", 0)
-	char := request.GetFloat("character", 0)
+	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
+	char := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
 
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil
@@ -67,8 +68,8 @@ func (s *Server) handleFindReferencesPrecise(ctx context.Context, request mcp.Ca
 			"uri": fmt.Sprintf("file://%s", path),
 		},
 		"position": map[string]interface{}{
-			"line":      int(line),
-			"character": int(char),
+			"line":      line,
+			"character": char,
 		},
 		"context": map[string]interface{}{
 			"includeDeclaration": true,
@@ -96,8 +97,8 @@ func (s *Server) handleFindReferencesPrecise(ctx context.Context, request mcp.Ca
 // handleGetTypeHierarchy uses the LSP to map out type structures.
 func (s *Server) handleGetTypeHierarchy(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	path := request.GetString("path", "")
-	line := request.GetFloat("line", 0)
-	char := request.GetFloat("character", 0)
+	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
+	char := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
 
 	if path == "" {
 		return mcp.NewToolResultError("path is required"), nil
@@ -113,8 +114,8 @@ func (s *Server) handleGetTypeHierarchy(ctx context.Context, request mcp.CallToo
 			"uri": fmt.Sprintf("file://%s", path),
 		},
 		"position": map[string]interface{}{
-			"line":      int(line),
-			"character": int(char),
+			"line":      line,
+			"character": char,
 		},
 	}
 
@@ -132,8 +133,8 @@ func (s *Server) handleGetTypeHierarchy(ctx context.Context, request mcp.CallToo
 func (s *Server) handleLspQuery(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	action := request.GetString("action", "")
 	path := request.GetString("path", "")
-	line := int(request.GetFloat("line", 0))
-	character := int(request.GetFloat("character", 0))
+	line := util.ClampInt(int(request.GetFloat("line", 0)), 0, 1_000_000)
+	character := util.ClampInt(int(request.GetFloat("character", 0)), 0, 10_000)
 
 	switch action {
 	case "definition":

--- a/internal/mcp/handlers_project.go
+++ b/internal/mcp/handlers_project.go
@@ -10,15 +10,16 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/nilesh32236/vector-mcp-go/internal/indexer"
+	"github.com/nilesh32236/vector-mcp-go/internal/util"
 )
 
 // handleGetCodebaseSkeleton returns a topological tree map of the codebase.
 func (s *Server) handleGetCodebaseSkeleton(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	targetPath := request.GetString("target_path", "")
-	maxDepth := int(request.GetFloat("max_depth", 3))
+	maxDepth := util.ClampInt(int(request.GetFloat("max_depth", 3)), 0, 20)
 	includePattern := request.GetString("include_pattern", "")
 	excludePattern := request.GetString("exclude_pattern", "")
-	maxItems := int(request.GetFloat("max_items", 1000))
+	maxItems := util.ClampInt(int(request.GetFloat("max_items", 1000)), 1, 10000)
 
 	root := s.cfg.ProjectRoot
 	if targetPath != "" {

--- a/internal/mcp/handlers_search.go
+++ b/internal/mcp/handlers_search.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/nilesh32236/vector-mcp-go/internal/db"
 	"github.com/nilesh32236/vector-mcp-go/internal/indexer"
+	"github.com/nilesh32236/vector-mcp-go/internal/util"
 )
 
 // handleFilesystemGrep performs a keyword or regex search across the project's files.
@@ -193,13 +194,10 @@ func (s *Server) handleSearchCodebase(ctx context.Context, request mcp.CallToolR
 	if query == "" {
 		return mcp.NewToolResultError("query is required"), nil
 	}
-	topK := int(request.GetFloat("topK", 10))
+	topK := util.ClampInt(int(request.GetFloat("topK", 10)), 1, 100)
 	category := request.GetString("category", "") // code, document, or empty
 	pathFilter := request.GetString("path_filter", "")
-	maxTokens := int(request.GetFloat("max_tokens", float64(indexer.MaxContextTokens)))
-	if maxTokens <= 0 {
-		maxTokens = indexer.MaxContextTokens
-	}
+	maxTokens := util.ClampInt(int(request.GetFloat("max_tokens", float64(indexer.MaxContextTokens))), 1, indexer.MaxContextTokens)
 
 	pids := request.GetStringSlice("cross_reference_projects", nil)
 	if len(pids) == 0 {
@@ -301,7 +299,13 @@ func (s *Server) handleSearchCodebase(ctx context.Context, request mcp.CallToolR
 		currentTokenCount += tokens
 	}
 
-	return mcp.NewToolResultText(out.String()), nil
+	resultText := out.String()
+	truncated := util.TruncateRuneSafe(resultText, 12000)
+	if truncated != resultText {
+		truncated += "\n... [Truncated for length]"
+	}
+
+	return mcp.NewToolResultText(truncated), nil
 }
 
 // handleSearchWorkspace unifies vector, regex, graph, and index status tools into a single "Fat Tool".
@@ -311,12 +315,7 @@ func (s *Server) handleSearchWorkspace(ctx context.Context, request mcp.CallTool
 	limitFloat := request.GetFloat("limit", 10)
 	pathFilter := request.GetString("path", "")
 
-	limit := int(limitFloat)
-	if limit <= 0 {
-		limit = 10
-	} else if limit > 100 {
-		limit = 100
-	}
+	limit := util.ClampInt(int(limitFloat), 1, 100)
 
 	switch action {
 	case "vector":

--- a/internal/mcp/handlers_search.go
+++ b/internal/mcp/handlers_search.go
@@ -197,7 +197,11 @@ func (s *Server) handleSearchCodebase(ctx context.Context, request mcp.CallToolR
 	topK := util.ClampInt(int(request.GetFloat("topK", 10)), 1, 100)
 	category := request.GetString("category", "") // code, document, or empty
 	pathFilter := request.GetString("path_filter", "")
-	maxTokens := util.ClampInt(int(request.GetFloat("max_tokens", float64(indexer.MaxContextTokens))), 1, indexer.MaxContextTokens)
+	maxTokensFloat := request.GetFloat("max_tokens", float64(indexer.MaxContextTokens))
+	if maxTokensFloat <= 0 {
+		maxTokensFloat = float64(indexer.MaxContextTokens)
+	}
+	maxTokens := util.ClampInt(int(maxTokensFloat), 1, indexer.MaxContextTokens)
 
 	pids := request.GetStringSlice("cross_reference_projects", nil)
 	if len(pids) == 0 {
@@ -315,6 +319,9 @@ func (s *Server) handleSearchWorkspace(ctx context.Context, request mcp.CallTool
 	limitFloat := request.GetFloat("limit", 10)
 	pathFilter := request.GetString("path", "")
 
+	if limitFloat <= 0 {
+		limitFloat = 10
+	}
 	limit := util.ClampInt(int(limitFloat), 1, 100)
 
 	switch action {

--- a/internal/util/guardrails.go
+++ b/internal/util/guardrails.go
@@ -1,0 +1,60 @@
+package util
+
+// ClampInt clamps value into the inclusive [min, max] range.
+// If min is greater than max, the bounds are swapped.
+func ClampInt(value, min, max int) int {
+	if min > max {
+		min, max = max, min
+	}
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+// ClampInt64 clamps value into the inclusive [min, max] range.
+// If min is greater than max, the bounds are swapped.
+func ClampInt64(value, min, max int64) int64 {
+	if min > max {
+		min, max = max, min
+	}
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+// ClampFloat64 clamps value into the inclusive [min, max] range.
+// If min is greater than max, the bounds are swapped.
+func ClampFloat64(value, min, max float64) float64 {
+	if min > max {
+		min, max = max, min
+	}
+	if value < min {
+		return min
+	}
+	if value > max {
+		return max
+	}
+	return value
+}
+
+// TruncateRuneSafe truncates by rune count, preventing UTF-8 multi-byte corruption.
+// For maxRunes <= 0, an empty string is returned.
+func TruncateRuneSafe(s string, maxRunes int) string {
+	if maxRunes <= 0 || len(s) == 0 {
+		return ""
+	}
+
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	return string(r[:maxRunes])
+}

--- a/internal/util/guardrails_test.go
+++ b/internal/util/guardrails_test.go
@@ -1,0 +1,106 @@
+package util
+
+import "testing"
+
+func TestClampInt(t *testing.T) {
+	tests := []struct {
+		name       string
+		value      int
+		min        int
+		max        int
+		expected   int
+	}{
+		{name: "within range", value: 5, min: 1, max: 10, expected: 5},
+		{name: "below range", value: -1, min: 1, max: 10, expected: 1},
+		{name: "above range", value: 99, min: 1, max: 10, expected: 10},
+		{name: "negative bounds", value: -8, min: -5, max: -1, expected: -5},
+		{name: "swapped bounds", value: 7, min: 10, max: 1, expected: 7},
+		{name: "swapped bounds below", value: -3, min: 10, max: 1, expected: 1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClampInt(tc.value, tc.min, tc.max)
+			if got != tc.expected {
+				t.Fatalf("ClampInt(%d, %d, %d) = %d, want %d", tc.value, tc.min, tc.max, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestClampInt64(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    int64
+		min      int64
+		max      int64
+		expected int64
+	}{
+		{name: "within range", value: 50, min: 1, max: 100, expected: 50},
+		{name: "below range", value: -100, min: -10, max: 10, expected: -10},
+		{name: "above range", value: 101, min: 1, max: 100, expected: 100},
+		{name: "swapped bounds", value: 7, min: 100, max: 1, expected: 7},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClampInt64(tc.value, tc.min, tc.max)
+			if got != tc.expected {
+				t.Fatalf("ClampInt64(%d, %d, %d) = %d, want %d", tc.value, tc.min, tc.max, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestClampFloat64(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    float64
+		min      float64
+		max      float64
+		expected float64
+	}{
+		{name: "within range", value: 0.5, min: 0.0, max: 1.0, expected: 0.5},
+		{name: "below range", value: -0.1, min: 0.0, max: 1.0, expected: 0.0},
+		{name: "above range", value: 1.1, min: 0.0, max: 1.0, expected: 1.0},
+		{name: "swapped bounds", value: 0.7, min: 1.0, max: 0.0, expected: 0.7},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ClampFloat64(tc.value, tc.min, tc.max)
+			if got != tc.expected {
+				t.Fatalf("ClampFloat64(%f, %f, %f) = %f, want %f", tc.value, tc.min, tc.max, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestTruncateRuneSafe(t *testing.T) {
+	invalidUTF8 := string([]byte{0xff, 0xfe, 'a', 0x80})
+
+	tests := []struct {
+		name     string
+		in       string
+		maxRunes int
+		expected string
+	}{
+		{name: "empty string", in: "", maxRunes: 5, expected: ""},
+		{name: "zero max", in: "hello", maxRunes: 0, expected: ""},
+		{name: "negative max", in: "hello", maxRunes: -5, expected: ""},
+		{name: "ascii truncate", in: "hello", maxRunes: 3, expected: "hel"},
+		{name: "ascii no truncate", in: "hello", maxRunes: 5, expected: "hello"},
+		{name: "multi-byte truncate", in: "Go語🙂", maxRunes: 3, expected: "Go語"},
+		{name: "multi-byte no truncate", in: "Go語🙂", maxRunes: 4, expected: "Go語🙂"},
+		{name: "invalid utf8 safe", in: invalidUTF8, maxRunes: 2, expected: string([]rune(invalidUTF8)[:2])},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := TruncateRuneSafe(tc.in, tc.maxRunes)
+			if got != tc.expected {
+				t.Fatalf("TruncateRuneSafe(%q, %d) = %q, want %q", tc.in, tc.maxRunes, got, tc.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Introduce deterministic guardrails for numeric inputs and string outputs to prevent invalid parameters and UTF-8 truncation issues across tools.
- Improve retrieval benchmarking capability with a small, polyglot fixture and a reproducible KPI benchmark.
- Capture a plan for technology verification and incremental modernization in repository docs.

### Description
- Add `internal/util/guardrails.go` providing `ClampInt`, `ClampInt64`, `ClampFloat64`, and `TruncateRuneSafe` for bounds checking and rune-safe truncation.  
- Add unit tests for the new utilities in `internal/util/guardrails_test.go`.  
- Apply the new guardrails across multiple handlers: `internal/api/handlers_tools.go`, `internal/mcp/handlers_analysis.go`, `internal/mcp/handlers_analysis_extended.go`, `internal/mcp/handlers_lsp.go`, `internal/mcp/handlers_project.go`, `internal/mcp/handlers_search.go`, and others to clamp incoming numeric params and to truncate long text outputs safely.  
- Ensure search and summarization responses use rune-safe truncation and append a `... [Truncated for length]` marker when content is shortened.  
- Add a polyglot benchmark fixture under `benchmark/fixtures/polyglot` (small Go, TypeScript, Python, and README) and a deterministic retrieval benchmark `benchmark/retrieval_bench_test.go` that computes recall@k, MRR, NDCG, index time per KLOC, and latencies using a deterministic embedder.  
- Add `docs/technology-modernization-plan.md` describing a phased plan for retrieval quality, performance, reliability, and ops improvements.

### Testing
- Ran the new utility unit tests with `go test ./internal/util` and all tests in `internal/util` passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb9b54bce48325962cf548e63ad9a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added polyglot benchmarking fixtures (Go/TypeScript/Python/Markdown), KPI thresholds, and a retrieval-quality benchmark.

* **Documentation**
  * Added a technology modernization plan with roadmap, constraints, and next steps.

* **Improvements**
  * Enforced safe numeric bounds for request parameters and consistent rune-safe truncation that appends "[Truncated for length]" when applied.

* **Tests**
  * Added unit tests for new clamping and safe-truncation utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->