### PR TITLE
⚡ Bolt: Hoist string lowercasing out of loops

### DIFF
--- a/internal/db/graph.go
+++ b/internal/db/graph.go
@@ -145,8 +145,9 @@ func (g *KnowledgeGraph) SearchByName(name string) []EntityNode {
 	g.mu.RLock()
 	defer g.mu.RUnlock()
 	var results []EntityNode
+	lowerName := strings.ToLower(name)
 	for _, n := range g.nodes {
-		if strings.Contains(strings.ToLower(n.Name), strings.ToLower(name)) {
+		if strings.Contains(strings.ToLower(n.Name), lowerName) {
 			results = append(results, n)
 		}
 	}

--- a/internal/mcp/handlers_search.go
+++ b/internal/mcp/handlers_search.go
@@ -31,12 +31,15 @@ func (s *Server) handleFilesystemGrep(ctx context.Context, request mcp.CallToolR
 	}
 
 	var re *regexp.Regexp
+	var lowerQuery string
 	if isRegex {
 		var err error
 		re, err = regexp.Compile(query)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Invalid regex: %v", err)), nil
 		}
+	} else {
+		lowerQuery = strings.ToLower(query)
 	}
 
 	maxMatches := 100
@@ -79,7 +82,7 @@ func (s *Server) handleFilesystemGrep(ctx context.Context, request mcp.CallToolR
 						if isRegex {
 							matched = re.MatchString(line)
 						} else {
-							matched = strings.Contains(strings.ToLower(line), strings.ToLower(query))
+							matched = strings.Contains(strings.ToLower(line), lowerQuery)
 						}
 
 						if matched {


### PR DESCRIPTION
Hoist string lowercasing out of loops

💡 What: Precomputed `strings.ToLower(query)` outside the main file/line iteration loop in `handleFilesystemGrep`, and hoisted `strings.ToLower(name)` out of the nodes loop in `SearchByName`.
🎯 Why: Calling `strings.ToLower` repeatedly on invariant parameters inside high-frequency loops (like per-line during grep or per-node during graph search) causes unnecessary allocations and CPU overhead, slowing down the search process significantly.
📊 Impact: Expected to reduce memory allocations proportionally to the number of lines/nodes processed, improving latency for graph and regex-based workspace searches.
🔬 Measurement: Verify by executing the `handleFilesystemGrep` and `handleSearchWorkspace` functions with regex disabled under load or via internal profiling to confirm allocation drop.

---
*PR created automatically by Jules for task [14700157582635005724](https://jules.google.com/task/14700157582635005724) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* Enhanced search performance by optimizing how search queries are processed internally. Name lookups and filtering operations now execute more efficiently, delivering faster response times and improved responsiveness, particularly when working with larger datasets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->