### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in MCP Handlers

### DIFF
--- a/internal/mcp/handlers_safety.go
+++ b/internal/mcp/handlers_safety.go
@@ -20,7 +20,12 @@ func (s *Server) handleVerifyPatchIntegrity(ctx context.Context, request mcp.Cal
 		return mcp.NewToolResultError("path and search are required"), nil
 	}
 
-	diags, err := s.safety.VerifyPatchIntegrity(ctx, path, search, replace)
+	absPath, err := s.validatePath(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid path: %v", err)), nil
+	}
+
+	diags, err := s.safety.VerifyPatchIntegrity(ctx, absPath, search, replace)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("verification failed: %v", err)), nil
 	}


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Unvalidated user-provided path parameter in `handleVerifyPatchIntegrity` allowed an attacker to read arbitrary files and conduct path traversal attacks by escaping the designated project root.
🎯 **Impact:** Allowed unauthenticated or authenticated users to read and verify patches against unauthorized sensitive files existing outside the permitted workspace directory context.
🔧 **Fix:** Added immediate sanitization and validation using `s.validatePath(path)` in the MCP handler layer before passing the path down to the backend `VerifyPatchIntegrity` function.
✅ **Verification:** Validated that the codebase safely filters traversal attempts. Ran `make fmt`, `make lint`, and `make test`. All checks complete securely with `0` errors.

---
*PR created automatically by Jules for task [6536231893899529716](https://jules.google.com/task/6536231893899529716) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced patch integrity verification with improved path validation to ensure safer operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->