### PR TITLE
🚔 Warden: [code quality improvement]

### DIFF
--- a/.jules/warden.md
+++ b/.jules/warden.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - O(N^2) Line Number Counting in String Chunking
+**Anti-Pattern:** Recalculating line numbers from the beginning of a file during string chunking loops (e.g., `strings.Count(string(runes[:i]), "\n")`). This creates an O(N^2) time complexity and massive memory allocations, as an expanding string is allocated from the heap on every single iteration of the chunk loop.
+**Standard:** When chunking text and needing to track line numbers, maintain a running `currentLine` counter outside the loop. In each iteration, update the counter by only applying `strings.Count` to the new, non-overlapping segment of text (`runes[lastI:i]`) and update `lastI`. This keeps complexity strictly O(N).

--- a/internal/indexer/chunker.go
+++ b/internal/indexer/chunker.go
@@ -574,10 +574,17 @@ func splitIfNeeded(c Chunk) []Chunk {
 	}
 
 	var chunks []Chunk
+	currentLine := c.StartLine
+	lastI := 0
 	for i := 0; i < len(runes); {
 		end := i + maxRunes
 		if end > len(runes) {
 			end = len(runes)
+		}
+
+		if i > lastI {
+			currentLine += strings.Count(string(runes[lastI:i]), "\n")
+			lastI = i
 		}
 
 		subContent := string(runes[i:end])
@@ -587,12 +594,8 @@ func splitIfNeeded(c Chunk) []Chunk {
 
 		newChunk := c
 		newChunk.Content = subContent
-		newChunk.EndLine = newChunk.StartLine + linesInSub
-		// Adjust start line for subsequent chunks
-		if i > 0 {
-			linesBefore := strings.Count(string(runes[:i]), "\n")
-			newChunk.StartLine = c.StartLine + linesBefore
-		}
+		newChunk.StartLine = currentLine
+		newChunk.EndLine = currentLine + linesInSub
 
 		chunks = append(chunks, newChunk)
 
@@ -754,14 +757,21 @@ func fastChunk(text string) []Chunk {
 		return nil
 	}
 
+	currentLine := 1
+	lastI := 0
 	for i := 0; i < len(runes); {
 		end := i + chunkSize
 		if end > len(runes) {
 			end = len(runes)
 		}
 
+		if i > lastI {
+			currentLine += strings.Count(string(runes[lastI:i]), "\n")
+			lastI = i
+		}
+
 		content := string(runes[i:end])
-		startLine := strings.Count(string(runes[:i]), "\n") + 1
+		startLine := currentLine
 		endLine := startLine + strings.Count(content, "\n")
 
 		chunks = append(chunks, Chunk{


### PR DESCRIPTION
💡 What: Refactored `fastChunk` and `splitIfNeeded` in `internal/indexer/chunker.go` to maintain a running `currentLine` count over non-overlapping text segments, rather than repeatedly slicing strings from the beginning (`runes[:i]`) to recount newlines.

🎯 Why: The previous implementation resulted in an `O(N^2)` time complexity algorithm that allocated increasingly massive strings onto the heap on every single loop iteration. For large files, this caused extreme slowdowns and OOM risks. This fix drops processing into strict `O(N)` linear time and prevents the heap allocations. It also patches a bug where `EndLine` references in `splitIfNeeded` were incorrectly bound to the initial chunk's start line.

---
*PR created automatically by Jules for task [12280528762132147052](https://jules.google.com/task/12280528762132147052) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved performance of chunk processing by optimizing line number tracking calculations.

* **Documentation**
  * Added documentation on string chunking best practices and common anti-patterns to avoid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->