### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in LSP and Safety MCP handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `handleSetProjectRoot` tool allowed updating `s.cfg.ProjectRoot` without re-initializing `s.pathValidator`.
 **Learning:** Security components (like path validators) that rely on configuration state (like `ProjectRoot`) must be updated synchronously when that state changes, otherwise validation bypass or false positives may occur.
 **Prevention:** Always re-initialize dependent security components when configuration state changes.
+
+## 2026-04-11 - Path Traversal in LSP and Safety Handlers
+**Vulnerability:** Found unvalidated absolute path resolution in `handleLspQuery` and `handleVerifyPatchIntegrity` where paths were passed directly from user requests via `request.GetString` into `getManagerForFile` and other system tools without passing through `s.validatePath`.
+**Learning:** Even internal tool calls or secondary features that interact with files must validate paths. A path parsed using `request.GetString` should never be trusted.
+**Prevention:** Always use `s.validatePath(path)` (or `s.pathValidator.ValidatePath(path)`) for all user-provided file paths in the MCP handler layer before using them or passing them to underlying modules.

--- a/internal/mcp/handlers_lsp.go
+++ b/internal/mcp/handlers_lsp.go
@@ -129,6 +129,15 @@ func (s *Server) handleGetTypeHierarchy(ctx context.Context, path string, line, 
 func (s *Server) handleLspQuery(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 	action := request.GetString("action", "")
 	path := request.GetString("path", "")
+
+	if path != "" {
+		validatedPath, err := s.validatePath(path)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("invalid path: %v", err)), nil
+		}
+		path = validatedPath
+	}
+
 	line, character := parseAndClampLSPPosition(request)
 
 	switch action {

--- a/internal/mcp/handlers_safety.go
+++ b/internal/mcp/handlers_safety.go
@@ -20,7 +20,12 @@ func (s *Server) handleVerifyPatchIntegrity(ctx context.Context, request mcp.Cal
 		return mcp.NewToolResultError("path and search are required"), nil
 	}
 
-	diags, err := s.safety.VerifyPatchIntegrity(ctx, path, search, replace)
+	validatedPath, err := s.validatePath(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid path: %v", err)), nil
+	}
+
+	diags, err := s.safety.VerifyPatchIntegrity(ctx, validatedPath, search, replace)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("verification failed: %v", err)), nil
 	}


### PR DESCRIPTION
This PR addresses a CRITICAL path traversal vulnerability in the MCP handlers for LSP query and Safety Patch Verification. 

User inputs extracted via `request.GetString("path", "")` were previously fed directly into `getManagerForFile` or `VerifyPatchIntegrity`, bypassing path verification. This fix ensures that `s.validatePath(path)` is applied to the path immediately after extraction, securing these code paths against directory traversal attacks.

The `.jules/sentinel.md` log has also been updated with this learning.

---
*PR created automatically by Jules for task [2070428656352485407](https://jules.google.com/task/2070428656352485407) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added path validation in LSP query operations to ensure safe handling of user-provided file paths
  * Added path validation in patch integrity verification before processing file paths
  * Enforced path validation across file operations to prevent unsafe file access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->