### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix path traversal in MCP handlers

### DIFF
--- a/internal/mcp/handlers_distill.go
+++ b/internal/mcp/handlers_distill.go
@@ -16,13 +16,18 @@ func (s *Server) handleDistillPackagePurpose(ctx context.Context, request mcp.Ca
 		return mcp.NewToolResultError("path (package directory) is required"), nil
 	}
 
+	absPath, err := s.validatePath(pkgPath)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid path: %v", err)), nil
+	}
+
 	store, err := s.getStore(ctx)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Failed to get store: %v", err)), nil
 	}
 
 	distiller := analysis.NewDistiller(store, s.embedder, s.logger)
-	summary, err := distiller.DistillPackagePurpose(ctx, s.projectRoot(), pkgPath)
+	summary, err := distiller.DistillPackagePurpose(ctx, s.projectRoot(), absPath)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("Distillation failed: %v", err)), nil
 	}

--- a/internal/mcp/handlers_safety.go
+++ b/internal/mcp/handlers_safety.go
@@ -20,7 +20,12 @@ func (s *Server) handleVerifyPatchIntegrity(ctx context.Context, request mcp.Cal
 		return mcp.NewToolResultError("path and search are required"), nil
 	}
 
-	diags, err := s.safety.VerifyPatchIntegrity(ctx, path, search, replace)
+	absPath, err := s.validatePath(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid path: %v", err)), nil
+	}
+
+	diags, err := s.safety.VerifyPatchIntegrity(ctx, absPath, search, replace)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("verification failed: %v", err)), nil
 	}


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: User-provided file paths in `handleDistillPackagePurpose` and `handleVerifyPatchIntegrity` were passed to underlying filesystem/LSP modules without passing through the project's centralized path validator, enabling potential Path Traversal vulnerabilities outside the active `ProjectRoot`.
🎯 Impact: Attackers could potentially read or mutate arbitrary system files or evaluate LSP rules against files outside the intended project boundary.
🔧 Fix: Enforced `s.validatePath` check for `pkgPath` and `path` parameters in `internal/mcp/handlers_distill.go` and `internal/mcp/handlers_safety.go` respectively, failing securely if invalid.
✅ Verification: Ran `make lint` and `make test`. Verified path validator rejects out-of-bounds traversal requests.

---
*PR created automatically by Jules for task [13888695705367854374](https://jules.google.com/task/13888695705367854374) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced path validation to ensure user-provided paths are properly validated before processing
  * Improved error handling with clearer feedback for invalid paths

<!-- end of auto-generated comment: release notes by coderabbit.ai -->