### PR TITLE
⚡ Bolt: Optimize line counting in chunker

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-04-06 - Remove strings.ToLower allocations from hot loops
 **Learning:** Calling `strings.ToLower` inside iteration loops (like per-line file scanning or graph node traversal) causes significant memory allocations and CPU overhead due to repeated string copying. A benchmark showed that hoisting `strings.ToLower` outside of hot loops, or early-returning on substring matches, reduces time overhead by roughly 30-40%.
 **Action:** Always hoist invariant string transformations (like lowercasing the search query) outside of hot loops. When iterating, prefer to pre-lower the entire text or only lower individual elements against a pre-lowered invariant.
+
+## 2024-04-13 - Optimize chunker.go line counting
+**Learning:** In string chunking loops, calculating line numbers by repeatedly scanning the entire preceding string (`strings.Count(string(runes[:i]), "\n")`) causes an O(n^2) performance bottleneck due to redundant string conversions and scans over previously processed bytes.
+**Action:** When tracking progress over sequential overlapping chunks, maintain a running tally of counts using only the non-overlapping segment from the last iteration to the current one.

--- a/internal/indexer/chunker.go
+++ b/internal/indexer/chunker.go
@@ -574,6 +574,9 @@ func splitIfNeeded(c Chunk) []Chunk {
 	}
 
 	var chunks []Chunk
+	currentLineOffset := 0
+	lastI := 0
+
 	for i := 0; i < len(runes); {
 		end := i + maxRunes
 		if end > len(runes) {
@@ -582,23 +585,25 @@ func splitIfNeeded(c Chunk) []Chunk {
 
 		subContent := string(runes[i:end])
 
+		if i > 0 {
+			currentLineOffset += strings.Count(string(runes[lastI:i]), "\n")
+		}
+
 		// Approximate lines
 		linesInSub := strings.Count(subContent, "\n")
 
 		newChunk := c
 		newChunk.Content = subContent
+		newChunk.StartLine = c.StartLine + currentLineOffset
 		newChunk.EndLine = newChunk.StartLine + linesInSub
-		// Adjust start line for subsequent chunks
-		if i > 0 {
-			linesBefore := strings.Count(string(runes[:i]), "\n")
-			newChunk.StartLine = c.StartLine + linesBefore
-		}
 
 		chunks = append(chunks, newChunk)
 
 		if end == len(runes) {
 			break
 		}
+
+		lastI = i
 		i += (maxRunes - overlap)
 	}
 	return chunks
@@ -754,6 +759,9 @@ func fastChunk(text string) []Chunk {
 		return nil
 	}
 
+	currentLine := 1
+	lastI := 0
+
 	for i := 0; i < len(runes); {
 		end := i + chunkSize
 		if end > len(runes) {
@@ -761,13 +769,17 @@ func fastChunk(text string) []Chunk {
 		}
 
 		content := string(runes[i:end])
-		startLine := strings.Count(string(runes[:i]), "\n") + 1
-		endLine := startLine + strings.Count(content, "\n")
+
+		if i > 0 {
+			currentLine += strings.Count(string(runes[lastI:i]), "\n")
+		}
+
+		endLine := currentLine + strings.Count(content, "\n")
 
 		chunks = append(chunks, Chunk{
 			Content:          content,
 			ContextualString: content,
-			StartLine:        startLine,
+			StartLine:        currentLine,
 			EndLine:          endLine,
 		})
 
@@ -775,6 +787,7 @@ func fastChunk(text string) []Chunk {
 			break
 		}
 
+		lastI = i
 		i += (chunkSize - overlap)
 	}
 	return chunks


### PR DESCRIPTION
💡 What: The optimization refactors `fastChunk` and `splitIfNeeded` in `internal/indexer/chunker.go` to use a running line sum (`currentLineOffset`) instead of recalculating lines from the beginning (`strings.Count(string(runes[:i]), "\n")`) for every chunk.

🎯 Why: To fix an O(N²) performance bottleneck and reduce heavy memory allocations caused by repeatedly converting growing substrings into strings inside the looping logic of `splitIfNeeded` and `fastChunk`.

📊 Impact: Reduces time complexity to O(N) per file. Significantly cuts CPU cycles and garbage collection pressure when chunking large files for embedding models.

🔬 Measurement: Verified the correctness of the optimization by writing and running test scripts (`test_chunker.go` and `test_chunker2.go`) with long mock content (20,000 lines). The output chunk start/end lines match between the original implementations and the new ones. Also executed `make test` and standard benchmarks `go test -bench=. ./internal/indexer`.

---
*PR created automatically by Jules for task [12301147041451557139](https://jules.google.com/task/12301147041451557139) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized line counting performance during text chunking operations to reduce redundant recalculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->