### PR TITLE
🚔 Warden: Improve error handling and traceability in LSP client

### DIFF
--- a/internal/lsp/client.go
+++ b/internal/lsp/client.go
@@ -90,16 +90,16 @@ func (m *Manager) EnsureStarted(ctx context.Context) error {
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create stdin pipe: %w", err)
 	}
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		return err
+		return fmt.Errorf("failed to start LSP server: %w", err)
 	}
 
 	m.cmd = cmd
@@ -138,7 +138,7 @@ func (m *Manager) Initialize(ctx context.Context) error {
 	var result any
 	err := m.callLocked(ctx, "initialize", params, &result)
 	if err != nil {
-		return err
+		return fmt.Errorf("initialize call failed: %w", err)
 	}
 
 	// Send initialized notification
@@ -153,7 +153,7 @@ func (m *Manager) initialize(ctx context.Context) error {
 // Call sends a request to the LSP and waits for a response.
 func (m *Manager) Call(ctx context.Context, method string, params any, result any) error {
 	if err := m.EnsureStarted(ctx); err != nil {
-		return err
+		return fmt.Errorf("failed to ensure LSP server is started: %w", err)
 	}
 
 	m.mu.Lock()
@@ -175,7 +175,7 @@ func (m *Manager) callLocked(ctx context.Context, method string, params any, res
 
 	data, err := json.Marshal(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal request (method=%s id=%v): %w", method, id, err)
 	}
 
 	ch := make(chan []byte, 1)
@@ -183,7 +183,7 @@ func (m *Manager) callLocked(ctx context.Context, method string, params any, res
 
 	if err := m.writeLocked(data); err != nil {
 		delete(m.pending, id)
-		return err
+		return fmt.Errorf("failed to write request (method=%s id=%v): %w", method, id, err)
 	}
 
 	m.mu.Unlock()
@@ -200,7 +200,7 @@ func (m *Manager) callLocked(ctx context.Context, method string, params any, res
 				} `json:"error"`
 			}
 			if err := json.Unmarshal(resp, &r); err != nil {
-				return err
+				return fmt.Errorf("failed to unmarshal response (method=%s id=%v): %w", method, id, err)
 			}
 			if r.Error != nil {
 				return fmt.Errorf("LSP error (%d): %s", r.Error.Code, r.Error.Message)
@@ -217,7 +217,7 @@ func (m *Manager) callLocked(ctx context.Context, method string, params any, res
 // Notify sends a notification to the LSP (no response expected).
 func (m *Manager) Notify(ctx context.Context, method string, params any) error {
 	if err := m.EnsureStarted(ctx); err != nil {
-		return err
+		return fmt.Errorf("failed to ensure LSP server is started: %w", err)
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -232,9 +232,12 @@ func (m *Manager) notifyLocked(method string, params any) error {
 	}
 	data, err := json.Marshal(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to marshal notification (method=%s): %w", method, err)
 	}
-	return m.writeLocked(data)
+	if err := m.writeLocked(data); err != nil {
+		return fmt.Errorf("failed to write notification (method=%s): %w", method, err)
+	}
+	return nil
 }
 
 // RegisterNotificationHandler registers a callback for a specific LSP notification method.
@@ -248,10 +251,10 @@ func (m *Manager) RegisterNotificationHandler(method string, handler func([]byte
 func (m *Manager) writeLocked(data []byte) error {
 	header := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(data))
 	if _, err := io.WriteString(m.stdin, header); err != nil {
-		return err
+		return fmt.Errorf("failed to write header: %w", err)
 	}
 	if _, err := m.stdin.Write(data); err != nil {
-		return err
+		return fmt.Errorf("failed to write body: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
💡 What: Wrapped all bare `return err` statements in `internal/lsp/client.go` with descriptive context using `fmt.Errorf("...: %w", err)`. Additionally, for LSP method communications, included the method name and request ID in the error format for better traceability.
🎯 Why: Improves codebase trace correlation and debuggability. Bare errors lack context making it hard to identify the source of the failure. Wrapping errors is idiomatic Go.

---
*PR created automatically by Jules for task [14094567752309676666](https://jules.google.com/task/14094567752309676666) started by @nilesh32236*