### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in MCP Handlers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `handleSetProjectRoot` tool allowed updating `s.cfg.ProjectRoot` without re-initializing `s.pathValidator`.
 **Learning:** Security components (like path validators) that rely on configuration state (like `ProjectRoot`) must be updated synchronously when that state changes, otherwise validation bypass or false positives may occur.
 **Prevention:** Always re-initialize dependent security components when configuration state changes.
+
+## 2025-04-18 - [CRITICAL] Path Traversal in MCP Handlers Bypassing pathValidator
+**Vulnerability:** The `handleVerifyPatchIntegrity` MCP handler in `internal/mcp/handlers_safety.go` failed to validate the user-provided `path` using `s.validatePath(path)` before passing it to `s.safety.VerifyPatchIntegrity()`.
+**Learning:** `handleVerifyPatchIntegrity` is an internal sub-handler that could be called with unvalidated input (e.g. from `handleModifyWorkspace` -> `verify_patch`), which allowed reading/interacting with files outside the allowed project workspace.
+**Prevention:** Always validate file paths derived from user input using `s.validatePath(path)` as early as possible in every individual MCP handler to ensure comprehensive path validation and security within boundaries.

--- a/internal/mcp/handlers_safety.go
+++ b/internal/mcp/handlers_safety.go
@@ -20,7 +20,12 @@ func (s *Server) handleVerifyPatchIntegrity(ctx context.Context, request mcp.Cal
 		return mcp.NewToolResultError("path and search are required"), nil
 	}
 
-	diags, err := s.safety.VerifyPatchIntegrity(ctx, path, search, replace)
+	absPath, err := s.validatePath(path)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("invalid path: %v", err)), nil
+	}
+
+	diags, err := s.safety.VerifyPatchIntegrity(ctx, absPath, search, replace)
 	if err != nil {
 		return mcp.NewToolResultError(fmt.Sprintf("verification failed: %v", err)), nil
 	}


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `handleVerifyPatchIntegrity` sub-handler did not validate the user-provided `path` using the server's path validation logic (`s.validatePath`) before passing it downstream. This allowed arbitrary file read/interaction outside the permitted workspace directory bounds.
🎯 Impact: An attacker could potentially supply an absolute path or traverse out of the project root to access sensitive files on the system or manipulate files outside the intended scope.
🔧 Fix: Added `s.validatePath(path)` to ensure the provided path is securely bounded within the `ProjectRoot` before executing the `s.safety.VerifyPatchIntegrity` logic.
✅ Verification: Ran `make fmt`, `make lint`, and `make test`. All passed. Reviewing code confirmed the input path string is successfully intercepted and safely validated.

---
*PR created automatically by Jules for task [2529400882457117233](https://jules.google.com/task/2529400882457117233) started by @nilesh32236*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a path traversal vulnerability that could enable unauthorized file access outside the intended workspace.
  * Strengthened input validation for file path operations.

* **Documentation**
  * Added critical security incident report and prevention guidelines to security log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->